### PR TITLE
build: namespace dialyzer plt by otp release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `JidoBrowser.Actions.ExtractContent`
   - `JidoBrowser.Actions.Evaluate`
 
-[Unreleased]: https://github.com/agentjido/jido_browser/compare/v0.8.1...HEAD
-[0.8.1]: https://github.com/agentjido/jido_browser/compare/v0.8.0...v0.8.1
+[Unreleased]: https://github.com/agentjido/jido_browser/compare/v0.8.0...HEAD
 [0.8.0]: https://github.com/agentjido/jido_browser/compare/v0.1.0...v0.8.0
 [0.1.0]: https://github.com/agentjido/jido_browser/releases/tag/v0.1.0


### PR DESCRIPTION
## Summary
- namespace the Dialyzer PLT file by OTP release (`priv/plts/dialyzer-otpXX.plt`)
- avoid reuse of incompatible cached PLTs in CI that triggered "Old PLT file" failures
- revert prior manual `CHANGELOG.md` edit to satisfy changelog-guard policy

## Validation
- `mix quality` (local) passes
