### PR TITLE
fix: support Elixir 1.20 strict compile

### DIFF
--- a/lib/jido_browser/web_fetch.ex
+++ b/lib/jido_browser/web_fetch.ex
@@ -1034,7 +1034,6 @@ defmodule Jido.Browser.WebFetch do
     %{uri | host: String.downcase(uri.host || ""), fragment: nil}
   end
 
-  defp normalize_rule_path(nil), do: "/"
   defp normalize_rule_path(""), do: "/"
   defp normalize_rule_path(path), do: if(String.starts_with?(path, "/"), do: path, else: "/" <> path)
 


### PR DESCRIPTION
## Summary
- Fix strict compiler warnings under Elixir 1.20 / OTP 29.
- Remove unused dependency lock entries where applicable.

## Verification
- mise exec erlang@29.0.1 elixir@1.20 -- mix compile --force --warnings-as-errors
- mise exec erlang@29.0.1 elixir@1.20 -- mix deps.unlock --check-unused
- mise exec erlang@29.0.1 elixir@1.20 -- mix format --check-formatted

Tests were not run; compile-only verification was requested.