### PR TITLE
test(actions): freeze the 2.x schema and tool contract

### DIFF
--- a/test/jido_browser/action_contract_content_composite_test.exs
+++ b/test/jido_browser/action_contract_content_composite_test.exs
@@ -1,0 +1,360 @@
+defmodule Jido.Browser.ActionContractContentCompositeTest do
+  use ExUnit.Case, async: false
+
+  import Jido.Browser.ActionContractAssertions
+
+  alias Jido.Browser.ActionContractInteractionQueryTest
+  alias Jido.Browser.ActionContractLifecycleNavigationTest
+  alias Jido.Browser.ActionContractToolExecutionProbe
+  alias Jido.Browser.Actions
+
+  @contracts [
+    %{
+      module: Actions.Snapshot,
+      name: "browser_snapshot",
+      description: "Get comprehensive LLM-friendly snapshot of the current page state",
+      schema: %{
+        include_links: %{type: :boolean, default: true, doc: "Include extracted links"},
+        include_forms: %{type: :boolean, default: true, doc: "Include form field info"},
+        include_headings: %{
+          type: :boolean,
+          default: true,
+          doc: "Include heading structure"
+        },
+        max_content_length: %{
+          type: :integer,
+          default: 50_000,
+          doc: "Truncate content at this length"
+        },
+        selector: %{
+          type: :string,
+          default: "body",
+          doc: "CSS selector to scope extraction"
+        }
+      }
+    },
+    %{
+      module: Actions.Screenshot,
+      name: "browser_screenshot",
+      description: "Take a screenshot of the current page",
+      schema: %{
+        full_page: %{
+          type: :boolean,
+          default: false,
+          doc: "Capture the full scrollable page"
+        },
+        format: %{
+          type: {:in, [:png]},
+          default: :png,
+          doc: "Image format (only PNG is currently supported)"
+        },
+        save_path: %{type: :string, doc: "Optional file path to save the screenshot"}
+      }
+    },
+    %{
+      module: Actions.ExtractContent,
+      name: "browser_extract_content",
+      description: "Extract content from the current page as markdown, HTML, or text",
+      schema: %{
+        selector: %{
+          type: :string,
+          default: "body",
+          doc: "CSS selector to scope extraction"
+        },
+        format: %{
+          type: {:in, [:markdown, :html, :text]},
+          default: :markdown,
+          doc: "Output format"
+        }
+      }
+    },
+    %{
+      module: Actions.WebFetch,
+      name: "web_fetch",
+      description:
+        "Fetch a URL over HTTP(S) with domain policy controls, Extractous-backed document extraction, " <>
+          "optional focused filtering, approximate token caps, and citation-ready passages.",
+      schema: %{
+        url: %{type: :string, required: true, doc: "The URL to fetch"},
+        format: %{
+          type: {:in, [:markdown, :text, :html]},
+          default: :markdown,
+          doc: "Output format"
+        },
+        backend: %{
+          type: {:in, [:req, :browsey]},
+          doc: "HTTP backend used for the fetch"
+        },
+        selector: %{type: :string, doc: "Optional CSS selector for HTML pages"},
+        allowed_domains: %{
+          type: {:list, :string},
+          default: [],
+          doc: "Allow-list of host or host/path rules"
+        },
+        blocked_domains: %{
+          type: {:list, :string},
+          default: [],
+          doc: "Block-list of host or host/path rules"
+        },
+        focus_terms: %{
+          type: {:list, :string},
+          default: [],
+          doc: "Terms used to filter the fetched document"
+        },
+        focus_window: %{
+          type: :integer,
+          default: 0,
+          doc: "Paragraph window around each focus match"
+        },
+        max_content_tokens: %{
+          type: :integer,
+          doc: "Approximate token cap for returned content"
+        },
+        citations: %{
+          type: :boolean,
+          default: false,
+          doc: "Include citation-ready passage offsets"
+        },
+        cache: %{
+          type: :boolean,
+          default: true,
+          doc: "Reuse cached fetch results when available"
+        },
+        timeout: %{type: :integer, doc: "Receive timeout in milliseconds"},
+        require_known_url: %{
+          type: :boolean,
+          default: false,
+          doc: "Require the URL to already be present in tool context"
+        },
+        known_urls: %{
+          type: {:list, :string},
+          default: [],
+          doc: "Additional known URLs accepted for provenance checks"
+        },
+        max_uses: %{
+          type: :integer,
+          doc: "Maximum successful web fetch calls allowed in current skill state"
+        }
+      }
+    },
+    %{
+      module: Actions.FetchRich,
+      name: "fetch_rich",
+      description:
+        "Fetch a URL with normalized rich content, using fast HTTP retrieval first and optional browser fallback.",
+      schema: %{
+        url: %{type: :string, required: true, doc: "The URL to fetch"},
+        format: %{
+          type: {:in, [:markdown, :text, :html]},
+          default: :markdown,
+          doc: "Output format"
+        },
+        backend: %{type: {:in, [:req, :browsey]}, doc: "Preferred HTTP backend"},
+        http_backends: %{
+          type: {:list, :atom},
+          doc: "HTTP backend sequence, such as [:req, :browsey]"
+        },
+        selector: %{
+          type: :string,
+          doc: "Optional CSS selector for HTML/browser extraction"
+        },
+        allowed_domains: %{
+          type: {:list, :string},
+          default: [],
+          doc: "Allow-list of host or host/path rules"
+        },
+        blocked_domains: %{
+          type: {:list, :string},
+          default: [],
+          doc: "Block-list of host or host/path rules"
+        },
+        focus_terms: %{
+          type: {:list, :string},
+          default: [],
+          doc: "Terms used to filter fetched documents"
+        },
+        focus_window: %{
+          type: :integer,
+          default: 0,
+          doc: "Paragraph window around each focus match"
+        },
+        max_content_tokens: %{
+          type: :integer,
+          doc: "Approximate token cap for returned content"
+        },
+        citations: %{
+          type: :boolean,
+          default: false,
+          doc: "Include citation-ready passage offsets"
+        },
+        cache: %{
+          type: :boolean,
+          default: true,
+          doc: "Reuse cached fetch results when available"
+        },
+        timeout: %{type: :integer, doc: "Timeout in milliseconds"},
+        browser_fallback: %{
+          type: :boolean,
+          default: false,
+          doc: "Allow fallback to a browser session"
+        },
+        pool: %{
+          type: :any,
+          doc: "Optional warm browser pool used for browser fallback"
+        },
+        checkout_timeout: %{type: :integer, doc: "Warm pool checkout timeout in ms"},
+        adapter: %{type: :atom, doc: "Browser adapter module for fallback"},
+        headless: %{type: :boolean, doc: "Run fallback browser headless"},
+        require_known_url: %{
+          type: :boolean,
+          default: false,
+          doc: "Require the URL to be present in context"
+        },
+        known_urls: %{
+          type: {:list, :string},
+          default: [],
+          doc: "Additional known URLs accepted for provenance"
+        },
+        max_uses: %{
+          type: :integer,
+          doc: "Maximum successful rich fetch calls allowed in current skill state"
+        }
+      }
+    },
+    %{
+      module: Actions.ReadPage,
+      name: "read_page",
+      description:
+        "Read a web page and return its content as markdown, text, or HTML. " <>
+          "Manages browser session automatically.",
+      schema: %{
+        url: %{type: :string, required: true, doc: "The URL to read"},
+        selector: %{
+          type: :string,
+          default: "body",
+          doc: "CSS selector to scope extraction"
+        },
+        format: %{
+          type: {:in, [:markdown, :text, :html]},
+          default: :markdown,
+          doc: "Output format"
+        },
+        pool: %{type: :any, doc: "Optional warm session pool name"},
+        checkout_timeout: %{type: :integer, doc: "Warm pool checkout timeout in ms"},
+        adapter: %{type: :atom, doc: "Browser adapter module"},
+        headless: %{type: :boolean, doc: "Run in headless mode"},
+        timeout: %{type: :integer, doc: "Default browser timeout in ms"}
+      }
+    },
+    %{
+      module: Actions.SnapshotUrl,
+      name: "snapshot_url",
+      description:
+        "Navigate to a URL and return a comprehensive LLM-friendly snapshot " <>
+          "including content, links, forms, and heading structure. Manages browser session automatically.",
+      schema: %{
+        url: %{type: :string, required: true, doc: "The URL to snapshot"},
+        selector: %{
+          type: :string,
+          default: "body",
+          doc: "CSS selector to scope extraction"
+        },
+        include_links: %{type: :boolean, default: true, doc: "Include extracted links"},
+        include_forms: %{type: :boolean, default: true, doc: "Include form field info"},
+        include_headings: %{
+          type: :boolean,
+          default: true,
+          doc: "Include heading structure"
+        },
+        max_content_length: %{
+          type: :integer,
+          default: 50_000,
+          doc: "Truncate content at this length"
+        },
+        pool: %{type: :any, doc: "Optional warm session pool name"},
+        checkout_timeout: %{type: :integer, doc: "Warm pool checkout timeout in ms"},
+        adapter: %{type: :atom, doc: "Browser adapter module"},
+        headless: %{type: :boolean, doc: "Run in headless mode"},
+        timeout: %{type: :integer, doc: "Default browser timeout in ms"}
+      }
+    },
+    %{
+      module: Actions.SearchWeb,
+      name: "search_web",
+      description:
+        "Search the web using Brave Search API and return structured results " <>
+          "with titles, URLs, and snippets.",
+      schema: %{
+        query: %{type: :string, required: true, doc: "Search query"},
+        max_results: %{
+          type: :integer,
+          default: 10,
+          doc: "Maximum number of results to return (max 20)"
+        },
+        country: %{
+          type: :string,
+          default: "us",
+          doc: "Country code for results (e.g. us, gb, de)"
+        },
+        search_lang: %{
+          type: :string,
+          default: "en",
+          doc: "Language code for results"
+        },
+        freshness: %{
+          type: :string,
+          doc: "Freshness filter: pd (24h), pw (week), pm (month), py (year)"
+        }
+      }
+    }
+  ]
+
+  for contract <- @contracts do
+    @contract contract
+
+    test "freezes the #{contract.name} schema and tool contract" do
+      assert_contract(@contract)
+    end
+  end
+
+  test "covers every production browser action exactly once" do
+    contract_modules =
+      ActionContractLifecycleNavigationTest.contracts()
+      |> Kernel.++(ActionContractInteractionQueryTest.contracts())
+      |> Kernel.++(@contracts)
+      |> Enum.map(& &1.module)
+
+    production_modules =
+      :jido_browser
+      |> Application.spec(:modules)
+      |> Enum.filter(fn module ->
+        String.starts_with?(Atom.to_string(module), "Elixir.Jido.Browser.Actions.") and
+          Code.ensure_loaded?(module) and function_exported?(module, :__action_metadata__, 0)
+      end)
+
+    assert length(contract_modules) == 40
+    assert length(Enum.uniq(contract_modules)) == 40
+    assert MapSet.new(contract_modules) == MapSet.new(production_modules)
+  end
+
+  @tag capture_log: true
+  test "generated tool function converts and validates Action 2.x input" do
+    tool = ActionContractToolExecutionProbe.to_tool()
+
+    assert {:ok, result_json} =
+             tool.function.(
+               %{"required_count" => "7", "unknown_input" => "kept"},
+               %{}
+             )
+
+    assert Jason.decode!(result_json) == %{
+             "label" => "default-label",
+             "required_count" => 7,
+             "unknown_input" => "kept"
+           }
+
+    assert {:error, error_json} = tool.function.(%{"unknown_input" => "kept"}, %{})
+    assert %{"error" => error_message} = Jason.decode!(error_json)
+    assert error_message =~ "required :required_count option not found"
+  end
+end

--- a/test/jido_browser/action_contract_interaction_query_test.exs
+++ b/test/jido_browser/action_contract_interaction_query_test.exs
@@ -1,0 +1,210 @@
+defmodule Jido.Browser.ActionContractInteractionQueryTest do
+  use ExUnit.Case, async: true
+
+  import Jido.Browser.ActionContractAssertions
+
+  alias Jido.Browser.Actions
+
+  @contracts [
+    %{
+      module: Actions.Click,
+      name: "browser_click",
+      description: "Click an element in the browser",
+      schema: %{
+        selector: %{
+          type: :string,
+          required: true,
+          doc: "CSS selector for the element to click"
+        },
+        text: %{
+          type: :string,
+          doc: "Optional text content to match within the selector"
+        },
+        timeout: %{type: :integer, doc: "Timeout in milliseconds"}
+      }
+    },
+    %{
+      module: Actions.Type,
+      name: "browser_type",
+      description: "Type text into an element in the browser",
+      schema: %{
+        selector: %{
+          type: :string,
+          required: true,
+          doc: "CSS selector for the input element"
+        },
+        text: %{type: :string, required: true, doc: "Text to type into the element"},
+        clear: %{type: :boolean, default: false, doc: "Clear the field before typing"},
+        timeout: %{type: :integer, doc: "Timeout in milliseconds"}
+      }
+    },
+    %{
+      module: Actions.Hover,
+      name: "browser_hover",
+      description: "Hover over an element in the browser",
+      schema: %{
+        selector: %{
+          type: :string,
+          required: true,
+          doc: "CSS selector for the element to hover"
+        },
+        timeout: %{type: :integer, doc: "Timeout in milliseconds"}
+      }
+    },
+    %{
+      module: Actions.Focus,
+      name: "browser_focus",
+      description: "Focus on an element in the browser",
+      schema: %{
+        selector: %{
+          type: :string,
+          required: true,
+          doc: "CSS selector for the element to focus"
+        },
+        timeout: %{type: :integer, doc: "Timeout in milliseconds"}
+      }
+    },
+    %{
+      module: Actions.Scroll,
+      name: "browser_scroll",
+      description: "Scroll the page by pixels, to preset positions, or to an element",
+      schema: %{
+        x: %{type: :integer, doc: "Horizontal scroll pixels"},
+        y: %{type: :integer, doc: "Vertical scroll pixels"},
+        direction: %{
+          type: {:in, [:up, :down, :top, :bottom]},
+          doc: "Preset scroll direction"
+        },
+        selector: %{type: :string, doc: "CSS selector to scroll element into view"}
+      }
+    },
+    %{
+      module: Actions.SelectOption,
+      name: "browser_select_option",
+      description: "Select an option from a dropdown element",
+      schema: %{
+        selector: %{
+          type: :string,
+          required: true,
+          doc: "CSS selector for the select element"
+        },
+        value: %{type: :string, doc: "Option value to select"},
+        label: %{type: :string, doc: "Option label/text to select"},
+        index: %{type: :integer, doc: "Option index to select (0-based)"}
+      }
+    },
+    %{
+      module: Actions.Wait,
+      name: "browser_wait",
+      description: "Wait for a specified number of milliseconds",
+      schema: %{
+        ms: %{type: :integer, required: true, doc: "Milliseconds to wait"}
+      }
+    },
+    %{
+      module: Actions.WaitForSelector,
+      name: "browser_wait_for_selector",
+      description: "Wait for an element to appear, disappear, or change visibility state",
+      schema: %{
+        selector: %{type: :string, required: true, doc: "CSS selector to wait for"},
+        state: %{
+          type: {:in, [:attached, :visible, :hidden, :detached]},
+          default: :visible,
+          doc: "State to wait for: :attached, :visible, :hidden, or :detached"
+        },
+        timeout: %{
+          type: :integer,
+          default: 30_000,
+          doc: "Maximum wait time in milliseconds"
+        }
+      }
+    },
+    %{
+      module: Actions.WaitForNavigation,
+      name: "browser_wait_for_navigation",
+      description: "Wait for page navigation to complete",
+      schema: %{
+        url: %{type: :string, doc: "URL pattern to match (substring match)"},
+        timeout: %{
+          type: :integer,
+          default: 30_000,
+          doc: "Maximum wait time in milliseconds"
+        }
+      }
+    },
+    %{
+      module: Actions.Query,
+      name: "browser_query",
+      description: "Query for elements matching a CSS selector",
+      schema: %{
+        selector: %{type: :string, required: true, doc: "CSS selector to query"},
+        limit: %{type: :integer, default: 10, doc: "Maximum number of elements to return"}
+      }
+    },
+    %{
+      module: Actions.GetText,
+      name: "browser_get_text",
+      description: "Get text content of an element",
+      schema: %{
+        selector: %{type: :string, required: true, doc: "CSS selector for the element"},
+        all: %{
+          type: :boolean,
+          default: false,
+          doc: "Get text from all matching elements"
+        }
+      }
+    },
+    %{
+      module: Actions.GetAttribute,
+      name: "browser_get_attribute",
+      description: "Get an attribute value from an element",
+      schema: %{
+        selector: %{type: :string, required: true, doc: "CSS selector for the element"},
+        attribute: %{type: :string, required: true, doc: "Attribute name to get"}
+      }
+    },
+    %{
+      module: Actions.IsVisible,
+      name: "browser_is_visible",
+      description: "Check if an element is visible",
+      schema: %{
+        selector: %{type: :string, required: true, doc: "CSS selector for the element"}
+      }
+    },
+    %{
+      module: Actions.Evaluate,
+      name: "browser_evaluate",
+      description: "Execute JavaScript in the browser and return the result",
+      schema: %{
+        script: %{type: :string, required: true, doc: "JavaScript code to execute"},
+        timeout: %{type: :integer, doc: "Timeout in milliseconds"}
+      }
+    },
+    %{
+      module: Actions.Console,
+      name: "browser_console",
+      description: "Read browser console messages",
+      schema: %{
+        timeout: %{type: :integer, doc: "Timeout in milliseconds"}
+      }
+    },
+    %{
+      module: Actions.Errors,
+      name: "browser_errors",
+      description: "Read browser runtime errors",
+      schema: %{
+        timeout: %{type: :integer, doc: "Timeout in milliseconds"}
+      }
+    }
+  ]
+
+  def contracts, do: @contracts
+
+  for contract <- @contracts do
+    @contract contract
+
+    test "freezes the #{contract.name} schema and tool contract" do
+      assert_contract(@contract)
+    end
+  end
+end

--- a/test/jido_browser/action_contract_lifecycle_navigation_test.exs
+++ b/test/jido_browser/action_contract_lifecycle_navigation_test.exs
@@ -1,0 +1,162 @@
+defmodule Jido.Browser.ActionContractLifecycleNavigationTest do
+  use ExUnit.Case, async: true
+
+  import Jido.Browser.ActionContractAssertions
+
+  alias Jido.Browser.Actions
+
+  @contracts [
+    %{
+      module: Actions.StartSession,
+      name: "browser_start_session",
+      description: "Start a new browser session",
+      schema: %{
+        headless: %{type: :boolean, doc: "Run in headless mode"},
+        timeout: %{type: :integer, doc: "Default timeout in ms"},
+        adapter: %{type: :atom, doc: "Browser adapter module"},
+        pool: %{type: :any, doc: "Optional warm session pool name"},
+        checkout_timeout: %{type: :integer, doc: "Warm pool checkout timeout in ms"}
+      }
+    },
+    %{
+      module: Actions.EndSession,
+      name: "browser_end_session",
+      description: "End the current browser session",
+      schema: %{}
+    },
+    %{
+      module: Actions.GetStatus,
+      name: "browser_get_status",
+      description: "Get current session status (url, title, is_alive)",
+      schema: %{}
+    },
+    %{
+      module: Actions.PoolStatus,
+      name: "browser_pool_status",
+      description: "Return readiness and lifecycle status for a warm browser pool.",
+      schema: %{
+        pool: %{type: :any, doc: "Warm pool name or pid. Defaults to plugin pool state."}
+      }
+    },
+    %{
+      module: Actions.Navigate,
+      name: "browser_navigate",
+      description: "Navigate the browser to a URL",
+      schema: %{
+        url: %{type: :string, required: true, doc: "The URL to navigate to"},
+        timeout: %{type: :integer, doc: "Timeout in milliseconds"}
+      }
+    },
+    %{
+      module: Actions.Back,
+      name: "browser_back",
+      description: "Navigate back in browser history",
+      schema: %{
+        timeout: %{type: :integer, doc: "Timeout in milliseconds"}
+      }
+    },
+    %{
+      module: Actions.Forward,
+      name: "browser_forward",
+      description: "Navigate forward in browser history",
+      schema: %{
+        timeout: %{type: :integer, doc: "Timeout in milliseconds"}
+      }
+    },
+    %{
+      module: Actions.Reload,
+      name: "browser_reload",
+      description: "Reload the current page",
+      schema: %{
+        timeout: %{type: :integer, doc: "Timeout in milliseconds"}
+      }
+    },
+    %{
+      module: Actions.GetUrl,
+      name: "browser_get_url",
+      description: "Get the current page URL",
+      schema: %{
+        timeout: %{type: :integer, doc: "Timeout in milliseconds"}
+      }
+    },
+    %{
+      module: Actions.GetTitle,
+      name: "browser_get_title",
+      description: "Get the current page title",
+      schema: %{
+        timeout: %{type: :integer, doc: "Timeout in milliseconds"}
+      }
+    },
+    %{
+      module: Actions.NewTab,
+      name: "browser_new_tab",
+      description: "Open a new browser tab",
+      schema: %{
+        url: %{type: :string, doc: "Optional URL to open in the new tab"},
+        timeout: %{type: :integer, doc: "Timeout in milliseconds"}
+      }
+    },
+    %{
+      module: Actions.CloseTab,
+      name: "browser_close_tab",
+      description: "Close a browser tab",
+      schema: %{
+        index: %{type: :integer, doc: "Optional tab index to close"},
+        timeout: %{type: :integer, doc: "Timeout in milliseconds"}
+      }
+    },
+    %{
+      module: Actions.SwitchTab,
+      name: "browser_switch_tab",
+      description: "Switch to another browser tab",
+      schema: %{
+        index: %{type: :integer, required: true, doc: "Tab index to activate"},
+        timeout: %{type: :integer, doc: "Timeout in milliseconds"}
+      }
+    },
+    %{
+      module: Actions.ListTabs,
+      name: "browser_list_tabs",
+      description: "List open browser tabs",
+      schema: %{
+        timeout: %{type: :integer, doc: "Timeout in milliseconds"}
+      }
+    },
+    %{
+      module: Actions.SaveState,
+      name: "browser_save_state",
+      description: "Save browser session state to a file",
+      schema: %{
+        path: %{
+          type: :string,
+          required: true,
+          doc: "Filesystem path where session state will be stored"
+        },
+        timeout: %{type: :integer, doc: "Timeout in milliseconds"}
+      }
+    },
+    %{
+      module: Actions.LoadState,
+      name: "browser_load_state",
+      description: "Load browser session state from a file",
+      schema: %{
+        path: %{
+          type: :string,
+          required: true,
+          doc: "Filesystem path of the saved session state"
+        },
+        timeout: %{type: :integer, doc: "Timeout in milliseconds"}
+      }
+    }
+  ]
+
+  def contracts, do: @contracts
+
+  for contract <- @contracts do
+    @contract contract
+
+    test "freezes the #{contract.name} schema and tool contract" do
+      assert_contract(@contract)
+    end
+  end
+end

--- a/test/support/action_contract_assertions.ex
+++ b/test/support/action_contract_assertions.ex
@@ -1,0 +1,223 @@
+defmodule Jido.Browser.ActionContractAssertions do
+  @moduledoc false
+
+  import ExUnit.Assertions
+
+  alias Jido.Action.Tool
+
+  @unknown_atom :contract_unknown_atom
+  @unknown_string "contract_unknown_string"
+
+  def assert_contract(%{module: action, name: name, description: description, schema: schema}) do
+    assert normalized_schema(action.schema()) == normalized_schema(schema)
+
+    assert_validation_contract(action, schema)
+    assert_tool_input_contract(action, schema)
+    assert_generated_tool_contract(action, name, description, schema)
+  end
+
+  defp assert_validation_contract(action, schema) do
+    all_atom_params = sample_params(schema)
+    required_atom_params = required_params(schema)
+
+    assert {:ok, ^all_atom_params} = action.validate_params(all_atom_params)
+
+    expected_minimal_params = Map.merge(required_atom_params, default_params(schema))
+    assert {:ok, ^expected_minimal_params} = action.validate_params(required_atom_params)
+
+    params_with_unknown_keys =
+      Map.merge(all_atom_params, %{@unknown_atom => :kept, @unknown_string => "kept"})
+
+    assert {:ok, ^params_with_unknown_keys} = action.validate_params(params_with_unknown_keys)
+
+    assert_direct_string_key_behavior(action, schema, required_atom_params)
+  end
+
+  defp assert_direct_string_key_behavior(action, schema, required_atom_params) do
+    optional_string_params =
+      schema
+      |> Enum.reject(fn {_key, options} -> Map.get(options, :required, false) end)
+      |> Map.new(fn {key, options} -> {Atom.to_string(key), sample_value(options.type, key)} end)
+
+    mixed_params = Map.merge(required_atom_params, optional_string_params)
+
+    expected_mixed_params =
+      required_atom_params
+      |> Map.merge(optional_string_params)
+      |> Map.merge(default_params(schema))
+
+    assert {:ok, ^expected_mixed_params} = action.validate_params(mixed_params)
+
+    case required_atom_params do
+      params when map_size(params) == 0 ->
+        :ok
+
+      params ->
+        required_string_params = Map.new(params, fn {key, value} -> {Atom.to_string(key), value} end)
+
+        assert {:error, %Jido.Action.Error.InvalidInputError{}} =
+                 action.validate_params(required_string_params)
+    end
+  end
+
+  defp assert_tool_input_contract(action, schema) do
+    all_atom_params = sample_params(schema)
+    all_string_params = Map.new(all_atom_params, fn {key, value} -> {Atom.to_string(key), value} end)
+
+    assert Tool.convert_params_using_schema(all_string_params, action.schema()) == all_atom_params
+
+    params_with_unknown_keys =
+      Map.merge(all_string_params, %{@unknown_atom => :kept, @unknown_string => "kept"})
+
+    assert Tool.convert_params_using_schema(params_with_unknown_keys, action.schema()) ==
+             Map.merge(all_atom_params, %{@unknown_atom => :kept, @unknown_string => "kept"})
+
+    assert_atom_key_precedence(action, schema)
+  end
+
+  defp assert_atom_key_precedence(_action, schema) when map_size(schema) == 0, do: :ok
+
+  defp assert_atom_key_precedence(action, schema) do
+    {key, options} = Enum.at(schema, 0)
+    atom_value = sample_value(options.type, key)
+    string_value = alternate_sample_value(options.type, key)
+
+    params = %{key => atom_value, Atom.to_string(key) => string_value}
+
+    assert Tool.convert_params_using_schema(params, action.schema()) == %{key => atom_value}
+  end
+
+  defp assert_generated_tool_contract(action, name, description, schema) do
+    tool = action.to_tool()
+
+    assert Map.keys(tool) |> Enum.sort() == [:description, :function, :name, :parameters_schema]
+    assert tool.name == name
+    assert tool.description == description
+    assert is_function(tool.function, 2)
+    assert normalize_json_schema(tool.parameters_schema) == expected_tool_schema(schema)
+  end
+
+  defp expected_tool_schema(schema) do
+    properties =
+      Map.new(schema, fn {key, options} ->
+        property =
+          options.type
+          |> json_type()
+          |> Map.put("description", options.doc)
+
+        {Atom.to_string(key), property}
+      end)
+
+    required =
+      schema
+      |> Enum.filter(fn {_key, options} -> Map.get(options, :required, false) end)
+      |> Enum.map(fn {key, _options} -> Atom.to_string(key) end)
+      |> Enum.sort()
+
+    %{
+      "additionalProperties" => false,
+      "properties" => properties,
+      "required" => required,
+      "type" => "object"
+    }
+    |> normalize_json_schema()
+  end
+
+  defp json_type(:string), do: %{"type" => "string"}
+  defp json_type(:integer), do: %{"type" => "integer"}
+  defp json_type(:boolean), do: %{"type" => "boolean"}
+  defp json_type(:float), do: %{"type" => "number"}
+  defp json_type(:number), do: %{"type" => "number"}
+  defp json_type(:non_neg_integer), do: %{"minimum" => 0, "type" => "integer"}
+  defp json_type(:pos_integer), do: %{"minimum" => 1, "type" => "integer"}
+  defp json_type(:atom), do: %{"type" => "string"}
+  defp json_type(:any), do: %{"type" => "string"}
+
+  defp json_type({:list, subtype}) do
+    %{"items" => json_type(subtype), "type" => "array"}
+  end
+
+  defp json_type({:in, values}) do
+    %{
+      "enum" => Enum.map(values, &enum_json_value/1),
+      "type" => enum_json_type(values)
+    }
+  end
+
+  defp enum_json_type(values) do
+    cond do
+      Enum.all?(values, &is_integer/1) -> "integer"
+      Enum.all?(values, &is_number/1) -> "number"
+      Enum.all?(values, &is_boolean/1) -> "boolean"
+      true -> "string"
+    end
+  end
+
+  defp enum_json_value(value) when is_atom(value), do: Atom.to_string(value)
+  defp enum_json_value(value), do: value
+
+  defp sample_params(schema) do
+    Map.new(schema, fn {key, options} -> {key, sample_value(options.type, key)} end)
+  end
+
+  defp required_params(schema) do
+    schema
+    |> Enum.filter(fn {_key, options} -> Map.get(options, :required, false) end)
+    |> Map.new(fn {key, options} -> {key, sample_value(options.type, key)} end)
+  end
+
+  defp default_params(schema) do
+    schema
+    |> Enum.filter(fn {_key, options} -> Map.has_key?(options, :default) end)
+    |> Map.new(fn {key, options} -> {key, options.default} end)
+  end
+
+  defp sample_value(:string, key), do: "sample_#{key}"
+  defp sample_value(:integer, _key), do: 7
+  defp sample_value(:boolean, _key), do: true
+  defp sample_value(:float, _key), do: 1.5
+  defp sample_value(:number, _key), do: 2
+  defp sample_value(:non_neg_integer, _key), do: 0
+  defp sample_value(:pos_integer, _key), do: 1
+  defp sample_value(:atom, _key), do: :contract_sample
+  defp sample_value(:any, _key), do: {:contract, :sample}
+  defp sample_value({:list, subtype}, key), do: [sample_value(subtype, key)]
+  defp sample_value({:in, [value | _values]}, _key), do: value
+
+  defp alternate_sample_value(:string, key), do: "alternate_#{key}"
+  defp alternate_sample_value(:integer, _key), do: 9
+  defp alternate_sample_value(:boolean, _key), do: false
+  defp alternate_sample_value(:float, _key), do: 2.5
+  defp alternate_sample_value(:number, _key), do: 3
+  defp alternate_sample_value(:non_neg_integer, _key), do: 2
+  defp alternate_sample_value(:pos_integer, _key), do: 2
+  defp alternate_sample_value(:atom, _key), do: :contract_alternate
+  defp alternate_sample_value(:any, _key), do: {:contract, :alternate}
+  defp alternate_sample_value({:list, subtype}, key), do: [alternate_sample_value(subtype, key)]
+  defp alternate_sample_value({:in, values}, _key), do: List.last(values)
+
+  defp normalized_schema(schema) do
+    Map.new(schema, fn {key, options} ->
+      normalized_options =
+        options
+        |> Map.new()
+        |> Map.update(:type, nil, &normalize_type/1)
+
+      {key, normalized_options}
+    end)
+  end
+
+  defp normalize_type({:in, values}), do: {:in, Enum.sort(values)}
+  defp normalize_type(type), do: type
+
+  defp normalize_json_schema(schema) when is_map(schema) do
+    Map.new(schema, fn
+      {"enum", values} -> {"enum", Enum.sort(values)}
+      {"required", values} -> {"required", Enum.sort(values)}
+      {key, value} -> {key, normalize_json_schema(value)}
+    end)
+  end
+
+  defp normalize_json_schema(values) when is_list(values), do: Enum.map(values, &normalize_json_schema/1)
+  defp normalize_json_schema(value), do: value
+end

--- a/test/support/action_contract_tool_execution_probe.ex
+++ b/test/support/action_contract_tool_execution_probe.ex
@@ -1,0 +1,14 @@
+defmodule Jido.Browser.ActionContractToolExecutionProbe do
+  @moduledoc false
+
+  use Jido.Action,
+    name: "action_contract_tool_execution_probe",
+    description: "Return validated parameters for action tool contract tests",
+    schema: [
+      required_count: [type: :integer, required: true, doc: "Required count"],
+      label: [type: :string, default: "default-label", doc: "Optional label"]
+    ]
+
+  @impl true
+  def run(params, _context), do: {:ok, params}
+end


### PR DESCRIPTION
## Summary

- Freeze the current input schema and generated strict tool schema for all 40 production browser actions.
- Record required fields, optional fields, defaults, enums, descriptions, and atom-key, string-key, and unknown-key behavior.
- Add test-only compatibility guards for the 2.x maintenance line before later action-schema refactors.

## Test evidence

- `mix test test/jido_browser/action_contract_*_test.exs` — 41 passed
- `mix test` — 253 passed, 25 excluded
- `mix compile --warnings-as-errors` — passed
- `mix format --check-formatted` — passed

Closes #73