### PR TITLE
fix(agent_browser): support AgentBrowser 0.35.1 daemon payloads

### DIFF
--- a/lib/jido_browser/adapters/agent_browser.ex
+++ b/lib/jido_browser/adapters/agent_browser.ex
@@ -175,6 +175,17 @@ defmodule Jido.Browser.Adapters.AgentBrowser do
   end
 
   @impl true
+  def command(session, :switch_tab, opts) do
+    run_tab_index_command(session, "tab_switch", Keyword.fetch!(opts, :index), opts)
+  end
+
+  def command(session, :close_tab, opts) do
+    case opts[:index] do
+      nil -> run(session, %{"action" => "tab_close"}, opts)
+      index -> run_tab_index_command(session, "tab_close", index, opts)
+    end
+  end
+
   def command(session, action, opts) do
     payload = command_payload(action, opts)
     run(session, payload, opts)
@@ -253,10 +264,37 @@ defmodule Jido.Browser.Adapters.AgentBrowser do
   defp command_payload(:load_state, opts), do: %{"action" => "state_load", "path" => Keyword.fetch!(opts, :path)}
   defp command_payload(:list_tabs, _opts), do: %{"action" => "tab_list"}
   defp command_payload(:new_tab, opts), do: maybe_put(%{"action" => "tab_new"}, "url", opts[:url])
-  defp command_payload(:switch_tab, opts), do: %{"action" => "tab_switch", "index" => Keyword.fetch!(opts, :index)}
-  defp command_payload(:close_tab, opts), do: maybe_put(%{"action" => "tab_close"}, "index", opts[:index])
   defp command_payload(:console, _opts), do: %{"action" => "console"}
   defp command_payload(:errors, _opts), do: %{"action" => "errors"}
+
+  defp run_tab_index_command(session, action, index, opts) do
+    with {:ok, session, tab_list} <- run(session, %{"action" => "tab_list"}, opts),
+         {:ok, tab_id} <- tab_id_at_index(tab_list, index) do
+      run(session, %{"action" => action, "tabId" => tab_id}, opts)
+    end
+  end
+
+  defp tab_id_at_index(%{"tabs" => tabs}, index)
+       when is_list(tabs) and is_integer(index) and index >= 0 do
+    case Enum.fetch(tabs, index) do
+      {:ok, %{"tabId" => tab_id}} when is_binary(tab_id) ->
+        {:ok, tab_id}
+
+      {:ok, tab} ->
+        {:error, Error.adapter_error("Invalid agent-browser tab list entry", %{index: index, tab: tab})}
+
+      :error ->
+        {:error, Error.adapter_error("Tab index out of range", %{index: index, tab_count: length(tabs)})}
+    end
+  end
+
+  defp tab_id_at_index(%{"tabs" => tabs}, index) when is_list(tabs) do
+    {:error, Error.adapter_error("Invalid tab index", %{index: index})}
+  end
+
+  defp tab_id_at_index(tab_list, index) do
+    {:error, Error.adapter_error("Invalid agent-browser tab list response", %{index: index, response: tab_list})}
+  end
 
   defp run(%Session{runtime: %{pooled: true, manager: pid}} = session, payload, opts) when is_pid(pid) do
     timeout = opts[:timeout] || @default_timeout

--- a/lib/jido_browser/agent_browser/runtime.ex
+++ b/lib/jido_browser/agent_browser/runtime.ex
@@ -7,7 +7,7 @@ defmodule Jido.Browser.AgentBrowser.Runtime do
   alias Jido.Browser.Error
   alias Jido.Browser.Installer
 
-  @supported_version "0.20.2"
+  @supported_version "0.35.1"
   @daemon_timeout 5_000
   @command_timeout 30_000
 

--- a/lib/jido_browser/installer.ex
+++ b/lib/jido_browser/installer.ex
@@ -31,7 +31,7 @@ defmodule Jido.Browser.Installer do
   @compile {:no_warn_undefined, LightpandaEx}
   require Logger
 
-  @agent_browser_version "0.20.2"
+  @agent_browser_version "0.35.1"
   @vibium_version "26.3.11"
   @web_version "main"
   @lightpanda_version "0.3.0"

--- a/test/jido_browser/adapters/agent_browser_integration_test.exs
+++ b/test/jido_browser/adapters/agent_browser_integration_test.exs
@@ -148,9 +148,13 @@ defmodule Jido.Browser.Adapters.AgentBrowserIntegrationTest do
       {:ok, _session, article_result} = Browser.get_url(session, timeout: @command_timeout)
       assert fetch_value(article_result, :url) == article_url
 
-      {:ok, session, _close_result} = Browser.close_tab(session, 1, timeout: @command_timeout)
+      {:ok, session, _close_result} = Browser.close_tab(session, 0, timeout: @command_timeout)
       {:ok, _session, remaining_tabs_result} = Browser.list_tabs(session, timeout: @command_timeout)
       assert length(tab_entries(remaining_tabs_result)) == 1
+
+      {:ok, session, _switch_result} = Browser.switch_tab(session, 0, timeout: @command_timeout)
+      {:ok, _session, remaining_url_result} = Browser.get_url(session, timeout: @command_timeout)
+      assert fetch_value(remaining_url_result, :url) == article_url
     end
   end
 

--- a/test/jido_browser/agent_browser_runtime_test.exs
+++ b/test/jido_browser/agent_browser_runtime_test.exs
@@ -1,6 +1,7 @@
 defmodule Jido.Browser.AgentBrowserRuntimeTest do
   use ExUnit.Case, async: false
 
+  alias Jido.Browser.Adapters.AgentBrowser
   alias Jido.Browser.AgentBrowser.PoolRuntime
   alias Jido.Browser.AgentBrowser.Runtime
   alias Jido.Browser.AgentBrowser.SessionServer
@@ -16,6 +17,32 @@ defmodule Jido.Browser.AgentBrowserRuntimeTest do
       assert Process.alive?(Process.whereis(Jido.Browser.WarmPool.RootSupervisor))
       assert Process.alive?(Process.whereis(Jido.Browser.WarmPool.Registry))
       assert Process.alive?(Process.whereis(Jido.Browser.WarmPool.Supervisor))
+    end
+  end
+
+  describe "adapter daemon payloads" do
+    test "resolves zero-based indexes against ordered stable tab identifiers" do
+      FakeAgentBrowser.with_binary(:normal, fn binary, _socket_dir ->
+        with_agent_browser_config([binary_path: binary], fn ->
+          assert {:ok, session} = Jido.Browser.start_session(adapter: AgentBrowser, timeout: 1_000)
+
+          try do
+            assert {:ok, ^session, %{"tabId" => "t2"}} =
+                     Jido.Browser.switch_tab(session, 1, timeout: 1_000)
+
+            assert {:ok, ^session, %{"tabId" => "t1"}} =
+                     Jido.Browser.close_tab(session, 0, timeout: 1_000)
+
+            assert {:ok, ^session, %{"tabId" => "t2"}} =
+                     Jido.Browser.switch_tab(session, 0, timeout: 1_000)
+
+            assert {:ok, ^session, %{"tabId" => "t3"}} =
+                     Jido.Browser.close_tab(session, 1, timeout: 1_000)
+          after
+            Jido.Browser.end_session(session)
+          end
+        end)
+      end)
     end
   end
 
@@ -143,10 +170,10 @@ defmodule Jido.Browser.AgentBrowserRuntimeTest do
     end
 
     test "parse_version and ensure_supported_version validate the binary version" do
-      assert {:ok, "0.20.2"} = Runtime.parse_version("agent-browser 0.20.2\n")
+      assert {:ok, "0.35.1"} = Runtime.parse_version("agent-browser 0.35.1\n")
       assert {:error, "unknown output"} = Runtime.parse_version("unknown output")
 
-      with_temporary_script("#!/bin/sh\nprintf 'agent-browser 0.20.2\\n'\n", fn binary ->
+      with_temporary_script("#!/bin/sh\nprintf 'agent-browser 0.35.1\\n'\n", fn binary ->
         assert :ok = Runtime.ensure_supported_version(binary)
       end)
 

--- a/test/jido_browser/composite_actions_and_installer_test.exs
+++ b/test/jido_browser/composite_actions_and_installer_test.exs
@@ -398,7 +398,7 @@ defmodule Jido.Browser.CompositeActionsAndInstallerTest do
       end)
 
       with_app_env(:jido_browser, :agent_browser_version, nil, fn ->
-        assert Installer.configured_version(:agent_browser) == "0.20.2"
+        assert Installer.configured_version(:agent_browser) == "0.35.1"
       end)
 
       with_app_env(:jido_browser, :agent_browser_version, "0.30.0", fn ->

--- a/test/support/fake_agent_browser.ex
+++ b/test/support/fake_agent_browser.ex
@@ -31,6 +31,11 @@ defmodule Jido.Browser.TestSupport.FakeAgentBrowser do
     #!/usr/bin/env elixir
     mode = #{inspect(to_string(mode))}
 
+    if System.argv() == ["--version"] do
+      IO.puts("agent-browser 0.35.1")
+      System.halt(0)
+    end
+
     defmodule FakeAgentBrowserDaemon do
       def run("exit_on_start") do
         IO.binwrite(:stderr, "boot failure")
@@ -53,7 +58,7 @@ defmodule Jido.Browser.TestSupport.FakeAgentBrowser do
             ifaddr: {:local, String.to_charlist(socket_path)}
           ])
 
-        accept_loop(listener, %{mode: mode, current_url: nil, action_counts: %{}})
+        accept_loop(listener, %{mode: mode, current_url: nil, action_counts: %{}, tabs: ["t1", "t2", "t3"]})
       end
 
       defp accept_loop(listener, state) do
@@ -79,11 +84,38 @@ defmodule Jido.Browser.TestSupport.FakeAgentBrowser do
           {:ok, line} ->
             action = capture(line, ~r/"action"\\s*:\\s*"([^"]+)"/)
             url = capture(line, ~r/"url"\\s*:\\s*"([^"]+)"/)
-            respond(socket, state, action, url)
+
+            if action in ["tab_switch", "tab_close"] do
+              respond_to_tab_command(socket, state, action, line)
+            else
+              respond(socket, state, action, url)
+            end
 
           {:error, reason} ->
             IO.binwrite(:stderr, "recv failed: \#{inspect(reason)}")
             {state, 92}
+        end
+      end
+
+      defp respond_to_tab_command(socket, state, action, line) do
+        tab_id = capture(line, ~r/"tabId"\\s*:\\s*"([^"]+)"/)
+
+        cond do
+          Regex.match?(~r/"index"\\s*:/, line) or is_nil(tab_id) ->
+            send_response(socket, false, nil, "expected tabId payload")
+            {state, nil}
+
+          tab_id not in state.tabs ->
+            send_response(socket, false, nil, "unknown stable tab ID")
+            {state, nil}
+
+          action == "tab_close" ->
+            send_response(socket, true, %{"tabId" => tab_id}, nil)
+            {%{state | tabs: List.delete(state.tabs, tab_id)}, nil}
+
+          true ->
+            send_response(socket, true, %{"tabId" => tab_id}, nil)
+            {state, nil}
         end
       end
 
@@ -124,6 +156,12 @@ defmodule Jido.Browser.TestSupport.FakeAgentBrowser do
         {state, nil}
       end
 
+      defp respond(socket, state, "tab_list", _url) do
+        tabs = Enum.map(state.tabs, &%{"tabId" => &1})
+        send_response(socket, true, %{"tabs" => tabs}, nil)
+        {state, nil}
+      end
+
       defp respond(socket, state, "close", _url) do
         send_response(socket, true, %{}, nil)
         {state, 0}
@@ -157,6 +195,7 @@ defmodule Jido.Browser.TestSupport.FakeAgentBrowser do
       end
 
       defp encode_value(map) when is_map(map), do: encode_map(map)
+      defp encode_value(list) when is_list(list), do: "[" <> Enum.map_join(list, ",", &encode_value/1) <> "]"
       defp encode_value(nil), do: "null"
       defp encode_value(true), do: "true"
       defp encode_value(false), do: "false"


### PR DESCRIPTION
## Summary

- Update the runtime-supported and installer download version from AgentBrowser 0.20.2 to 0.35.1.
- Keep the supervised direct daemon transport.
- Keep the public zero-based tab index API.
- Resolve each indexed tab switch or close against the current ordered tab_list and send that entry actual stable tabId.
- Update the direct unit test, fake daemon fixture, and real integration case for stable IDs after removal.

## Payload behavior

- Before an indexed switch or close, the adapter requests tab_list.
- The requested public index selects the matching entry in the current ordered list.
- The adapter sends that entry tabId to AgentBrowser 0.35.1.
- After t1 closes, t2 becomes public index 0. A switch of index 0 sends tabId t2.
- A close without an index still closes the current tab.
- No public API, binary precedence, broad installer behavior, CI, or MCP change is included.

## Test evidence

- Repository installer: mix jido_browser.install agent_browser --force
- Installed binary: agent-browser 0.35.1
- Installed binary SHA-256: 12be3313ec6d878d8fda62ca5c62b7013c1b6931bf57dd2678788654b01ffe95
- Real 0.35.1 local-fixture integration test: 10 passed
- Direct unit tests: 32 passed
- Full unit tests: 256 passed, 25 integration tests excluded
- MIX_ENV=test mix compile --warnings-as-errors
- mix format --check-formatted
- mix quality
- mix docs -f html

Closes #96

This PR unblocks #66.