### PR TITLE
refactor(session): derive the struct contract from Zoi

### DIFF
--- a/lib/jido_browser/session.ex
+++ b/lib/jido_browser/session.ex
@@ -9,29 +9,21 @@ defmodule Jido.Browser.Session do
   @schema Zoi.struct(
             __MODULE__,
             %{
-              id: Zoi.string(),
-              adapter: Zoi.any(),
-              connection: Zoi.any() |> Zoi.nullish(),
-              runtime: Zoi.any() |> Zoi.nullish(),
-              capabilities: Zoi.any() |> Zoi.default(%{}),
-              started_at: Zoi.any(),
-              opts: Zoi.any() |> Zoi.default(%{})
+              id: Zoi.string(typespec: quote(do: String.t())),
+              adapter: Zoi.any(typespec: quote(do: module())),
+              connection: Zoi.any() |> Zoi.nullish(typespec: quote(do: term())),
+              runtime: Zoi.any() |> Zoi.nullish(typespec: quote(do: map() | nil)),
+              capabilities: Zoi.any() |> Zoi.default(%{}, typespec: quote(do: map())),
+              started_at: Zoi.any(typespec: quote(do: DateTime.t())),
+              opts: Zoi.any() |> Zoi.default(%{}, typespec: quote(do: map()))
             },
             coerce: true
           )
 
-  @type t :: %__MODULE__{
-          id: String.t(),
-          adapter: module(),
-          connection: term(),
-          runtime: map() | nil,
-          capabilities: map(),
-          started_at: DateTime.t(),
-          opts: map()
-        }
+  @type t :: unquote(Zoi.type_spec(@schema))
 
-  @enforce_keys [:id, :adapter, :started_at]
-  defstruct [:id, :adapter, :connection, :runtime, started_at: nil, capabilities: %{}, opts: %{}]
+  @enforce_keys Zoi.Struct.enforce_keys(@schema)
+  defstruct Zoi.Struct.struct_fields(@schema)
 
   @doc """
   Returns the Zoi schema for this struct.

--- a/test/jido_browser/session_test.exs
+++ b/test/jido_browser/session_test.exs
@@ -3,6 +3,24 @@ defmodule Jido.Browser.SessionTest do
 
   alias Jido.Browser.Session
 
+  test "derives the raw struct contract from the schema" do
+    struct_contract = Macro.struct_info!(Session, __ENV__)
+
+    required_keys = MapSet.new(Zoi.Struct.enforce_keys(Session.schema()))
+
+    assert required_keys == MapSet.new([:id, :adapter, :started_at])
+
+    assert Map.new(struct_contract, &{&1.field, &1.default}) == %{
+             id: nil,
+             adapter: nil,
+             connection: nil,
+             runtime: nil,
+             capabilities: %{},
+             started_at: nil,
+             opts: %{}
+           }
+  end
+
   describe "new/1" do
     test "creates session with required fields" do
       assert {:ok, session} =
@@ -27,12 +45,19 @@ defmodule Jido.Browser.SessionTest do
       assert session.id == "custom-id"
     end
 
-    test "defaults opts to empty map" do
+    test "requires an adapter" do
+      assert {:error, [%Zoi.Error{code: :required, path: [:adapter]}]} = Session.new(%{})
+    end
+
+    test "uses the session defaults" do
       assert {:ok, session} =
                Session.new(%{
                  adapter: Jido.Browser.Adapters.Vibium
                })
 
+      assert session.connection == nil
+      assert session.runtime == nil
+      assert session.capabilities == %{}
       assert session.opts == %{}
     end
   end


### PR DESCRIPTION
## Summary

- derive the Session public type, required keys, and struct fields from its existing Zoi schema
- use the pinned Zoi 0.18.7 `typespec:` metadata to preserve the exact public field types without changing parsing
- add focused constructor, required-adapter, default-value, and direct raw struct-contract coverage

## Compatibility evidence

The locked Zoi 0.18.7 implementation provides `Zoi.type_spec/1`, `Zoi.Struct.enforce_keys/1`, and `Zoi.Struct.struct_fields/1`. Its custom `typespec:` metadata is compile-time schema metadata and does not add validation, coercion, or refinement.

The generated contract keeps all seven fields and their public types: `id: String.t()`, `adapter: module()`, `connection: term()`, `runtime: map() | nil`, `capabilities: map()`, `started_at: DateTime.t()`, and `opts: map()`. It keeps required keys `id`, `adapter`, and `started_at`; nil raw defaults for `id`, `adapter`, `connection`, `runtime`, and `started_at`; and empty-map raw defaults for `capabilities` and `opts`.

The raw contract test uses `Zoi.Struct.enforce_keys/1` for the exact required-key set and the public Elixir 1.18 `Macro.struct_info!/2` API for the exact raw field/default map. It does not call a constructor.

`new/1`, `new!/1`, tagged tuples, and session ID generation are unchanged. No callers or other schemas changed.

## Checks

- `mix test test/jido_browser/session_test.exs` — 7 passed
- `mix test` — 258 passed, 25 excluded
- `mix compile --warnings-as-errors`
- `mix format --check-formatted`
- `mix quality`
- `mix docs --warnings-as-errors`
- `git diff --check origin/main...HEAD`

Closes #62