### PR TITLE
test(coverage): enforce the current coverage baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,4 +22,4 @@ jobs:
     secrets: inherit
     with:
       docs_command: mix docs -f html
-      test_command: mix test
+      test_command: mix coveralls

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,6 +51,10 @@ Pull requests are squash merged. The Conventional Commit title of the pull reque
 - Ensure existing tests pass
 - Use Mimic for mocking external dependencies
 
+`mix coveralls` enforces the coverage floor in
+`coveralls.json` at `coverage_options.minimum_coverage`. When a feature or bug fix
+raises the coverage baseline, raise this floor in the same pull request.
+
 ## Commit Messages
 
 Use Conventional Commits:

--- a/coveralls.json
+++ b/coveralls.json
@@ -1,0 +1,5 @@
+{
+  "coverage_options": {
+    "minimum_coverage": 53.0
+  }
+}


### PR DESCRIPTION
## Summary

- Set `coverage_options.minimum_coverage` to 53.0% in `coveralls.json`.
- Run `mix coveralls` in the shared CI test lane.
- Document where and when maintainers raise the floor.
- Keep the current coverage exclusions unchanged.

## Evidence

- Baseline: `mix coveralls` exited 0 with 255 tests passed, 25 integration tests excluded, and 54.5% total coverage at the committed 53.0% floor.
- Failure proof: a temporary local 55.0% floor made `mix coveralls` exit 1 at 54.4% total coverage with `FAILED: Expected minimum coverage of 55.0%, got 54.4%.` The floor was restored to 53.0% before the commit.
- Compile: `mix compile --warnings-as-errors` passed.
- Format: `mix format --check-formatted` passed.
- CI command: `agentjido/github-actions/.github/workflows/jido-ci.yml@v5` supports the `test_command` input and passes it to the shared test workflow. This PR sets `test_command: mix coveralls`.

Closes #68
