### PR TITLE
chore(dialyzer): remove the stale Web adapter ignore

### DIFF
--- a/.dialyzer_ignore.exs
+++ b/.dialyzer_ignore.exs
@@ -1,9 +1,0 @@
-# Dialyzer false positives
-# 
-# The Web adapter's pattern matches are correct, but dialyzer over-constrains
-# the return type because it tracks through Application.get_env which can
-# return nil at compile time but will have actual config at runtime.
-[
-  # Web adapter - dialyzer incorrectly infers only error return from run_web_command
-  {"lib/jido_browser/adapters/web.ex", :pattern_match}
-]

--- a/mix.exs
+++ b/mix.exs
@@ -209,8 +209,7 @@ defmodule Jido.Browser.MixProject do
       flags: [
         :error_handling,
         :unknown
-      ],
-      ignore_warnings: ".dialyzer_ignore.exs"
+      ]
     ]
   end
 end


### PR DESCRIPTION
## Description

- Remove the obsolete Web adapter pattern-match Dialyzer filter.
- Delete the now-empty `.dialyzer_ignore.exs` file.
- Remove the stale `ignore_warnings` setting from `mix.exs`.
- Do not change production code, type specifications, adapter behavior, tests, or coverage settings.

## Dialyzer evidence

Command: `mix dialyzer --list-unused-filters`

```text
Total errors: 0, Skipped: 0, Unnecessary Skips: 0
done (passed successfully)
```

The same zero-error and zero-skip result passed again after the branch was rebased on current `main`.

## Validation

- [x] `mix compile --warnings-as-errors`
- [x] `mix format --check-formatted`
- [x] `mix coveralls` — 256 passed, 25 excluded, 55.0% total coverage (53.0% minimum)
- [x] `mix quality`
- [x] `mix docs -f html`
- [x] Diff contains only `.dialyzer_ignore.exs` and Dialyzer configuration in `mix.exs`
- [x] `CHANGELOG.md` is unchanged

Closes #90