### PR TITLE
fix(agent_browser): make binary selection deterministic

### DIFF
--- a/lib/jido_browser/agent_browser/binary.ex
+++ b/lib/jido_browser/agent_browser/binary.ex
@@ -4,10 +4,37 @@ defmodule Jido.Browser.AgentBrowser.Binary do
   alias Jido.Browser.Error
 
   @supported_version "0.35.1"
+  @binary_name "agent-browser"
+
+  @type source :: :configured | :package | :path
 
   @doc false
   @spec supported_version() :: String.t()
   def supported_version, do: @supported_version
+
+  @doc false
+  @spec resolve(String.t(), keyword()) :: {:ok, String.t()} | {:error, Error.AdapterError.t()}
+  def resolve(package_path, opts \\ []) when is_binary(package_path) do
+    configured_path = Keyword.get_lazy(opts, :configured_path, &configured_path/0)
+
+    case configured_path do
+      nil -> resolve_candidates(package_path, opts)
+      "" -> resolve_candidates(package_path, opts)
+      path when is_binary(path) -> validate(path, :configured)
+      path -> {:error, invalid_configured_path_error(path)}
+    end
+  end
+
+  @doc false
+  @spec validate(String.t(), source()) :: {:ok, String.t()} | {:error, Error.AdapterError.t()}
+  def validate(path, source) when is_binary(path) do
+    with :ok <- validate_file(path, source),
+         :ok <- ensure_supported_version(path) do
+      {:ok, path}
+    else
+      {:error, %Error.AdapterError{} = error} -> {:error, add_source(error, path, source)}
+    end
+  end
 
   @doc false
   @spec ensure_supported_version(String.t()) :: :ok | {:error, Error.AdapterError.t()}
@@ -49,4 +76,106 @@ defmodule Jido.Browser.AgentBrowser.Binary do
       _ -> {:error, String.trim(output)}
     end
   end
+
+  defp resolve_candidates(package_path, opts) do
+    if File.exists?(package_path) do
+      case validate(package_path, :package) do
+        {:ok, _path} = result -> result
+        {:error, error} -> resolve_path_candidate(opts, error)
+      end
+    else
+      resolve_path_candidate(opts, nil)
+    end
+  end
+
+  defp resolve_path_candidate(opts, package_error) do
+    path_binary = Keyword.get_lazy(opts, :path_binary, fn -> System.find_executable(@binary_name) end)
+
+    case path_binary do
+      nil -> {:error, package_error || binary_not_found_error()}
+      "" -> {:error, package_error || binary_not_found_error()}
+      path when is_binary(path) -> validate(path, :path)
+      path -> {:error, invalid_path_candidate_error(path)}
+    end
+  end
+
+  defp validate_file(path, source) do
+    case File.stat(path) do
+      {:ok, %File.Stat{type: :regular} = stat} ->
+        if executable?(path, stat) do
+          :ok
+        else
+          {:error,
+           Error.adapter_error("#{source_label(source)} agent-browser binary is not executable", %{
+             path: path,
+             source: source
+           })}
+        end
+
+      {:ok, _stat} ->
+        {:error,
+         Error.adapter_error("#{source_label(source)} agent-browser binary is not a regular file", %{
+           path: path,
+           source: source
+         })}
+
+      {:error, :enoent} ->
+        {:error,
+         Error.adapter_error("#{source_label(source)} agent-browser binary was not found", %{
+           path: path,
+           source: source
+         })}
+
+      {:error, reason} ->
+        {:error,
+         Error.adapter_error("Could not inspect #{source_label(source, :lower)} agent-browser binary", %{
+           path: path,
+           reason: reason,
+           source: source
+         })}
+    end
+  end
+
+  defp executable?(path, stat) do
+    case :os.type() do
+      {:win32, _} -> String.downcase(Path.extname(path)) in [".exe", ".com", ".bat", ".cmd"]
+      _ -> Bitwise.band(stat.mode, 0o111) != 0
+    end
+  end
+
+  defp add_source(%{details: %{source: _existing_source}} = error, _path, _source), do: error
+
+  defp add_source(error, path, source) do
+    details = Map.merge(error.details || %{}, %{path: path, source: source})
+    %{error | message: "#{source_label(source)} agent-browser binary: #{error.message}", details: details}
+  end
+
+  defp configured_path do
+    :jido_browser
+    |> Application.get_env(:agent_browser, [])
+    |> Keyword.get(:binary_path)
+  end
+
+  defp invalid_configured_path_error(path) do
+    Error.adapter_error("Configured agent-browser binary path must be a non-empty string", %{
+      path: path,
+      source: :configured
+    })
+  end
+
+  defp invalid_path_candidate_error(path) do
+    Error.adapter_error("PATH agent-browser binary path must be a string", %{path: path, source: :path})
+  end
+
+  defp binary_not_found_error do
+    Error.adapter_error("agent-browser binary not found. Install with: mix jido_browser.install agent_browser", %{
+      supported: @supported_version
+    })
+  end
+
+  defp source_label(:configured), do: "Configured"
+  defp source_label(:package), do: "Packaged"
+  defp source_label(:path), do: "PATH"
+
+  defp source_label(source, :lower), do: source |> source_label() |> String.downcase()
 end

--- a/lib/jido_browser/agent_browser/binary.ex
+++ b/lib/jido_browser/agent_browser/binary.ex
@@ -1,0 +1,52 @@
+defmodule Jido.Browser.AgentBrowser.Binary do
+  @moduledoc false
+
+  alias Jido.Browser.Error
+
+  @supported_version "0.35.1"
+
+  @doc false
+  @spec supported_version() :: String.t()
+  def supported_version, do: @supported_version
+
+  @doc false
+  @spec ensure_supported_version(String.t()) :: :ok | {:error, Error.AdapterError.t()}
+  def ensure_supported_version(binary) do
+    case System.cmd(binary, ["--version"], stderr_to_stdout: true) do
+      {output, 0} ->
+        case parse_version(output) do
+          {:ok, @supported_version} ->
+            :ok
+
+          {:ok, version} ->
+            {:error,
+             Error.adapter_error("Unsupported agent-browser version", %{
+               supported: @supported_version,
+               detected: version
+             })}
+
+          {:error, reason} ->
+            {:error, Error.adapter_error("Could not parse agent-browser version", %{reason: reason})}
+        end
+
+      {output, code} ->
+        {:error,
+         Error.adapter_error("Failed to inspect agent-browser version", %{
+           exit_status: code,
+           output: String.trim(output)
+         })}
+    end
+  rescue
+    error ->
+      {:error, Error.adapter_error("Failed to inspect agent-browser version", %{reason: Exception.message(error)})}
+  end
+
+  @doc false
+  @spec parse_version(String.t()) :: {:ok, String.t()} | {:error, String.t()}
+  def parse_version(output) do
+    case Regex.run(~r/agent-browser\s+(\d+\.\d+\.\d+)/, output, capture: :all_but_first) do
+      [version] -> {:ok, version}
+      _ -> {:error, String.trim(output)}
+    end
+  end
+end

--- a/lib/jido_browser/agent_browser/runtime.ex
+++ b/lib/jido_browser/agent_browser/runtime.ex
@@ -3,8 +3,8 @@ defmodule Jido.Browser.AgentBrowser.Runtime do
 
   import Bitwise
 
-  alias Jido.Browser.Application, as: BrowserApplication
   alias Jido.Browser.AgentBrowser.Binary
+  alias Jido.Browser.Application, as: BrowserApplication
   alias Jido.Browser.Installer
 
   @daemon_timeout 5_000
@@ -39,21 +39,7 @@ defmodule Jido.Browser.AgentBrowser.Runtime do
 
   @doc false
   @spec find_binary() :: {:ok, String.t()} | {:error, term()}
-  def find_binary do
-    case config(:binary_path) do
-      path when is_binary(path) and path != "" ->
-        if File.exists?(path), do: {:ok, path}, else: {:error, "Binary not found at #{path}"}
-
-      _ ->
-        case System.find_executable("agent-browser") || Installer.bin_path(:agent_browser) do
-          nil ->
-            {:error, "agent-browser binary not found. Install with: mix jido_browser.install agent_browser"}
-
-          path ->
-            {:ok, path}
-        end
-    end
-  end
+  def find_binary, do: Binary.resolve(Installer.agent_browser_package_path())
 
   @doc false
   @spec ensure_supported_version(String.t()) :: :ok | {:error, term()}

--- a/lib/jido_browser/agent_browser/runtime.ex
+++ b/lib/jido_browser/agent_browser/runtime.ex
@@ -4,10 +4,9 @@ defmodule Jido.Browser.AgentBrowser.Runtime do
   import Bitwise
 
   alias Jido.Browser.Application, as: BrowserApplication
-  alias Jido.Browser.Error
+  alias Jido.Browser.AgentBrowser.Binary
   alias Jido.Browser.Installer
 
-  @supported_version "0.35.1"
   @daemon_timeout 5_000
   @command_timeout 30_000
 
@@ -24,7 +23,7 @@ defmodule Jido.Browser.AgentBrowser.Runtime do
 
   @doc false
   @spec supported_version() :: String.t()
-  def supported_version, do: @supported_version
+  defdelegate supported_version(), to: Binary
 
   @doc false
   @spec default_command_timeout() :: pos_integer()
@@ -58,44 +57,11 @@ defmodule Jido.Browser.AgentBrowser.Runtime do
 
   @doc false
   @spec ensure_supported_version(String.t()) :: :ok | {:error, term()}
-  def ensure_supported_version(binary) do
-    case System.cmd(binary, ["--version"], stderr_to_stdout: true) do
-      {output, 0} ->
-        case parse_version(output) do
-          {:ok, @supported_version} ->
-            :ok
-
-          {:ok, version} ->
-            {:error,
-             Error.adapter_error("Unsupported agent-browser version", %{
-               supported: @supported_version,
-               detected: version
-             })}
-
-          {:error, reason} ->
-            {:error, Error.adapter_error("Could not parse agent-browser version", %{reason: reason})}
-        end
-
-      {output, code} ->
-        {:error,
-         Error.adapter_error("Failed to inspect agent-browser version", %{
-           exit_status: code,
-           output: String.trim(output)
-         })}
-    end
-  rescue
-    error ->
-      {:error, Error.adapter_error("Failed to inspect agent-browser version", %{reason: Exception.message(error)})}
-  end
+  defdelegate ensure_supported_version(binary), to: Binary
 
   @doc false
   @spec parse_version(String.t()) :: {:ok, String.t()} | {:error, String.t()}
-  def parse_version(output) do
-    case Regex.run(~r/agent-browser\s+(\d+\.\d+\.\d+)/, output, capture: :all_but_first) do
-      [version] -> {:ok, version}
-      _ -> {:error, String.trim(output)}
-    end
-  end
+  defdelegate parse_version(output), to: Binary
 
   @doc false
   @spec ensure_session_server(String.t(), session_opts()) :: {:ok, pid(), map()} | {:error, term()}

--- a/lib/jido_browser/installer.ex
+++ b/lib/jido_browser/installer.ex
@@ -31,7 +31,8 @@ defmodule Jido.Browser.Installer do
   @compile {:no_warn_undefined, LightpandaEx}
   require Logger
 
-  @agent_browser_version "0.35.1"
+  alias Jido.Browser.AgentBrowser.Binary
+
   @vibium_version "26.3.11"
   @web_version "main"
   @lightpanda_version "0.3.0"
@@ -142,8 +143,7 @@ defmodule Jido.Browser.Installer do
   Returns the configured version for a binary.
   """
   @spec configured_version(atom()) :: String.t()
-  def configured_version(:agent_browser),
-    do: Application.get_env(:jido_browser, :agent_browser_version, @agent_browser_version)
+  def configured_version(:agent_browser), do: Binary.supported_version()
 
   def configured_version(:vibium), do: Application.get_env(:jido_browser, :vibium_version, @vibium_version)
   def configured_version(:web), do: Application.get_env(:jido_browser, :web_version, @web_version)

--- a/lib/jido_browser/installer.ex
+++ b/lib/jido_browser/installer.ex
@@ -90,10 +90,10 @@ defmodule Jido.Browser.Installer do
     adapter = opts[:adapter] || configured_adapter_binary()
     force = opts[:force] || false
 
-    if force || not installed?(adapter) do
-      install(adapter, opts)
-    else
-      :ok
+    cond do
+      adapter == :agent_browser -> ensure_agent_browser_installed(opts, force)
+      force || not installed?(adapter) -> install(adapter, opts)
+      true -> :ok
     end
   end
 
@@ -104,9 +104,16 @@ defmodule Jido.Browser.Installer do
   def install(binary, opts \\ [])
 
   def install(:agent_browser, opts) do
-    install_path = opts[:path] || default_install_path()
-    force = opts[:force] || false
-    install_agent_browser(install_path, force)
+    if configured_agent_browser_path?() do
+      case resolve_agent_browser() do
+        {:ok, _path} -> :ok
+        {:error, reason} -> {:error, reason}
+      end
+    else
+      install_path = opts[:path] || default_install_path()
+      force = opts[:force] || false
+      install_agent_browser(install_path, force)
+    end
   end
 
   def install(:vibium, opts) do
@@ -139,6 +146,12 @@ defmodule Jido.Browser.Installer do
     end
   end
 
+  @doc false
+  @spec agent_browser_package_path() :: String.t()
+  def agent_browser_package_path do
+    Path.join(default_install_path(), agent_browser_binary_name())
+  end
+
   @doc """
   Returns the configured version for a binary.
   """
@@ -164,10 +177,7 @@ defmodule Jido.Browser.Installer do
   end
 
   defp agent_browser_installed? do
-    case find_agent_browser_path() do
-      nil -> false
-      path -> File.exists?(path)
-    end
+    match?({:ok, _path}, resolve_agent_browser())
   end
 
   defp vibium_installed? do
@@ -192,13 +202,37 @@ defmodule Jido.Browser.Installer do
   end
 
   defp find_agent_browser_path do
-    case configured_path(:agent_browser) do
-      path when is_binary(path) and path != "" ->
-        if File.exists?(path), do: path, else: nil
-
-      _ ->
-        find_in_path(agent_browser_binary_name()) || find_in_jido_browser_bin(agent_browser_binary_name())
+    case resolve_agent_browser() do
+      {:ok, path} -> path
+      {:error, _reason} -> nil
     end
+  end
+
+  defp resolve_agent_browser do
+    Binary.resolve(agent_browser_package_path())
+  end
+
+  defp ensure_agent_browser_installed(opts, force) do
+    cond do
+      configured_agent_browser_path?() ->
+        case resolve_agent_browser() do
+          {:ok, _path} -> :ok
+          {:error, reason} -> {:error, reason}
+        end
+
+      force ->
+        install(:agent_browser, opts)
+
+      true ->
+        case resolve_agent_browser() do
+          {:ok, _path} -> :ok
+          {:error, _reason} -> install(:agent_browser, opts)
+        end
+    end
+  end
+
+  defp configured_agent_browser_path? do
+    configured_path(:agent_browser) not in [nil, ""]
   end
 
   defp find_vibium_path do
@@ -318,18 +352,25 @@ defmodule Jido.Browser.Installer do
   defp install_agent_browser(install_path, force) do
     target = Path.join(install_path, agent_browser_binary_name())
 
-    if File.exists?(target) and not force do
-      Logger.info("agent-browser already installed at #{target}. Use --force to overwrite.")
-      :ok
-    else
-      File.mkdir_p!(install_path)
-      url = agent_browser_download_url()
-      Logger.info("Downloading agent-browser from #{url}...")
+    case {force, Binary.validate(target, :package)} do
+      {false, {:ok, _path}} ->
+        Logger.info("agent-browser already installed at #{target}. Use --force to overwrite.")
+        :ok
 
-      with :ok <- download_binary(url, target),
-           :ok <- File.chmod(target, 0o755) do
-        run_agent_browser_install(target)
-      end
+      _ ->
+        download_and_install_agent_browser(install_path, target)
+    end
+  end
+
+  defp download_and_install_agent_browser(install_path, target) do
+    File.mkdir_p!(install_path)
+    url = agent_browser_download_url()
+    Logger.info("Downloading agent-browser from #{url}...")
+
+    with :ok <- download_binary(url, target),
+         :ok <- File.chmod(target, 0o755),
+         {:ok, ^target} <- Binary.validate(target, :package) do
+      run_agent_browser_install(target)
     end
   end
 

--- a/test/jido_browser/agent_browser_binary_test.exs
+++ b/test/jido_browser/agent_browser_binary_test.exs
@@ -1,0 +1,69 @@
+defmodule Jido.Browser.AgentBrowserBinaryTest do
+  use ExUnit.Case, async: false
+
+  alias Jido.Browser.AgentBrowser.Binary
+  alias Jido.Browser.AgentBrowser.Runtime
+  alias Jido.Browser.Installer
+
+  describe "supported version contract" do
+    test "is shared by the binary, runtime, and installer" do
+      assert Binary.supported_version() == "0.35.1"
+      assert Runtime.supported_version() == Binary.supported_version()
+      assert Installer.configured_version(:agent_browser) == Binary.supported_version()
+    end
+
+    test "does not allow the installer version to differ from the runtime version" do
+      previous = Application.get_env(:jido_browser, :agent_browser_version, :not_set)
+      Application.put_env(:jido_browser, :agent_browser_version, "0.30.0")
+
+      try do
+        assert Installer.configured_version(:agent_browser) == Binary.supported_version()
+      after
+        restore_env(:agent_browser_version, previous)
+      end
+    end
+  end
+
+  describe "version validation" do
+    test "accepts the supported version" do
+      with_binary("agent-browser 0.35.1", fn binary ->
+        assert :ok = Binary.ensure_supported_version(binary)
+      end)
+    end
+
+    test "rejects an incompatible version" do
+      with_binary("agent-browser 0.34.0", fn binary ->
+        assert {:error, error} = Binary.ensure_supported_version(binary)
+        assert Exception.message(error) == "Unsupported agent-browser version"
+        assert error.details.detected == "0.34.0"
+        assert error.details.supported == "0.35.1"
+      end)
+    end
+
+    test "rejects an unparsable version" do
+      with_binary("unknown version", fn binary ->
+        assert {:error, error} = Binary.ensure_supported_version(binary)
+        assert Exception.message(error) == "Could not parse agent-browser version"
+        assert error.details.reason == "unknown version"
+      end)
+    end
+  end
+
+  defp with_binary(version_output, fun) do
+    directory = Path.join(System.tmp_dir!(), "jido_browser_binary_#{System.unique_integer([:positive])}")
+    binary = Path.join(directory, "agent-browser")
+
+    File.mkdir_p!(directory)
+    File.write!(binary, "#!/bin/sh\nprintf '%s\\n' '#{version_output}'\n")
+    File.chmod!(binary, 0o755)
+
+    try do
+      fun.(binary)
+    after
+      File.rm_rf!(directory)
+    end
+  end
+
+  defp restore_env(key, :not_set), do: Application.delete_env(:jido_browser, key)
+  defp restore_env(key, value), do: Application.put_env(:jido_browser, key, value)
+end

--- a/test/jido_browser/agent_browser_binary_test.exs
+++ b/test/jido_browser/agent_browser_binary_test.exs
@@ -49,18 +49,205 @@ defmodule Jido.Browser.AgentBrowserBinaryTest do
     end
   end
 
-  defp with_binary(version_output, fun) do
-    directory = Path.join(System.tmp_dir!(), "jido_browser_binary_#{System.unique_integer([:positive])}")
-    binary = Path.join(directory, "agent-browser")
+  describe "binary resolution" do
+    test "uses a compatible configured binary before package and PATH binaries" do
+      with_binary_directory(fn directory ->
+        configured = write_binary(directory, "configured", "agent-browser 0.35.1")
+        package = write_binary(directory, "package", "agent-browser 0.35.1")
+        path = write_binary(directory, "path", "agent-browser 0.35.1")
 
+        assert {:ok, ^configured} =
+                 Binary.resolve(package, configured_path: configured, path_binary: path)
+      end)
+    end
+
+    test "does not fall through when a configured binary is missing" do
+      with_binary_directory(fn directory ->
+        missing = Path.join(directory, "missing")
+        package = write_binary(directory, "package", "agent-browser 0.35.1")
+        path = write_binary(directory, "path", "agent-browser 0.35.1")
+
+        assert {:error, error} =
+                 Binary.resolve(package, configured_path: missing, path_binary: path)
+
+        assert Exception.message(error) == "Configured agent-browser binary was not found"
+        assert error.details.path == missing
+      end)
+    end
+
+    test "does not fall through when a configured binary is not executable" do
+      with_binary_directory(fn directory ->
+        configured = write_binary(directory, "configured", "agent-browser 0.35.1", 0o644)
+        package = write_binary(directory, "package", "agent-browser 0.35.1")
+        path = write_binary(directory, "path", "agent-browser 0.35.1")
+
+        assert {:error, error} =
+                 Binary.resolve(package, configured_path: configured, path_binary: path)
+
+        assert Exception.message(error) == "Configured agent-browser binary is not executable"
+      end)
+    end
+
+    test "does not fall through when a configured binary version is unparsable" do
+      with_binary_directory(fn directory ->
+        configured = write_binary(directory, "configured", "unknown version")
+        package = write_binary(directory, "package", "agent-browser 0.35.1")
+        path = write_binary(directory, "path", "agent-browser 0.35.1")
+
+        assert {:error, error} =
+                 Binary.resolve(package, configured_path: configured, path_binary: path)
+
+        assert Exception.message(error) ==
+                 "Configured agent-browser binary: Could not parse agent-browser version"
+      end)
+    end
+
+    test "does not fall through when a configured binary version is incompatible" do
+      with_binary_directory(fn directory ->
+        configured = write_binary(directory, "configured", "agent-browser 0.34.0")
+        package = write_binary(directory, "package", "agent-browser 0.35.1")
+        path = write_binary(directory, "path", "agent-browser 0.35.1")
+
+        assert {:error, error} =
+                 Binary.resolve(package, configured_path: configured, path_binary: path)
+
+        assert Exception.message(error) ==
+                 "Configured agent-browser binary: Unsupported agent-browser version"
+      end)
+    end
+
+    test "uses a compatible package binary before an incompatible PATH binary" do
+      with_binary_directory(fn directory ->
+        package = write_binary(directory, "package", "agent-browser 0.35.1")
+        path = write_binary(directory, "path", "agent-browser 0.34.0")
+
+        assert {:ok, ^package} =
+                 Binary.resolve(package, configured_path: nil, path_binary: path)
+      end)
+    end
+
+    test "uses a compatible PATH binary when the package binary is incompatible" do
+      with_binary_directory(fn directory ->
+        package = write_binary(directory, "package", "agent-browser 0.34.0")
+        path = write_binary(directory, "path", "agent-browser 0.35.1")
+
+        assert {:ok, ^path} =
+                 Binary.resolve(package, configured_path: nil, path_binary: path)
+      end)
+    end
+
+    test "returns a clear error when no candidate exists" do
+      with_binary_directory(fn directory ->
+        package = Path.join(directory, "missing-package")
+
+        assert {:error, error} =
+                 Binary.resolve(package, configured_path: nil, path_binary: nil)
+
+        assert Exception.message(error) =~ "agent-browser binary not found"
+        assert error.details.supported == "0.35.1"
+      end)
+    end
+  end
+
+  describe "runtime and installer resolution" do
+    test "both prefer the compatible package binary over an incompatible PATH binary" do
+      with_binary_directory(fn directory ->
+        package_directory = Path.join(directory, "package")
+        path_directory = Path.join(directory, "path")
+
+        with_env(:path, package_directory, fn ->
+          package = write_binary_path(Installer.agent_browser_package_path(), "agent-browser 0.35.1")
+          _path = write_binary(path_directory, "agent-browser", "agent-browser 0.34.0")
+
+          with_system_path(path_directory, fn ->
+            with_agent_browser_config([], fn ->
+              assert {:ok, ^package} = Runtime.find_binary()
+              assert Installer.bin_path(:agent_browser) == package
+              assert Installer.installed?(:agent_browser)
+            end)
+          end)
+        end)
+      end)
+    end
+
+    test "installer returns a configured-path error without installing another binary" do
+      with_binary_directory(fn directory ->
+        missing = Path.join(directory, "missing-configured")
+
+        with_agent_browser_config([binary_path: missing], fn ->
+          assert {:error, error} = Installer.ensure_installed(adapter: :agent_browser)
+          assert Exception.message(error) == "Configured agent-browser binary was not found"
+
+          assert {:error, install_error} =
+                   Installer.install(:agent_browser, path: Path.join(directory, "install-target"))
+
+          assert Exception.message(install_error) == "Configured agent-browser binary was not found"
+          refute File.exists?(Path.join(directory, "install-target"))
+          refute Installer.installed?(:agent_browser)
+          assert is_nil(Installer.bin_path(:agent_browser))
+        end)
+      end)
+    end
+  end
+
+  defp with_binary(version_output, fun) do
+    with_binary_directory(fn directory ->
+      fun.(write_binary(directory, "agent-browser", version_output))
+    end)
+  end
+
+  defp with_binary_directory(fun) do
+    directory = Path.join(System.tmp_dir!(), "jido_browser_binary_#{System.unique_integer([:positive])}")
     File.mkdir_p!(directory)
-    File.write!(binary, "#!/bin/sh\nprintf '%s\\n' '#{version_output}'\n")
-    File.chmod!(binary, 0o755)
 
     try do
-      fun.(binary)
+      fun.(directory)
     after
       File.rm_rf!(directory)
+    end
+  end
+
+  defp write_binary(directory, name, version_output, mode \\ 0o755) do
+    write_binary_path(Path.join(directory, name), version_output, mode)
+  end
+
+  defp write_binary_path(path, version_output, mode \\ 0o755) do
+    File.mkdir_p!(Path.dirname(path))
+    File.write!(path, "#!/bin/sh\nprintf '%s\\n' '#{version_output}'\n")
+    File.chmod!(path, mode)
+    path
+  end
+
+  defp with_agent_browser_config(config, fun) do
+    previous = Application.get_env(:jido_browser, :agent_browser, :not_set)
+    Application.put_env(:jido_browser, :agent_browser, config)
+
+    try do
+      fun.()
+    after
+      restore_env(:agent_browser, previous)
+    end
+  end
+
+  defp with_env(key, value, fun) do
+    previous = Application.get_env(:jido_browser, key, :not_set)
+    Application.put_env(:jido_browser, key, value)
+
+    try do
+      fun.()
+    after
+      restore_env(key, previous)
+    end
+  end
+
+  defp with_system_path(directory, fun) do
+    previous = System.get_env("PATH")
+    System.put_env("PATH", directory)
+
+    try do
+      fun.()
+    after
+      if previous, do: System.put_env("PATH", previous), else: System.delete_env("PATH")
     end
   end
 

--- a/test/jido_browser/agent_browser_runtime_test.exs
+++ b/test/jido_browser/agent_browser_runtime_test.exs
@@ -158,14 +158,15 @@ defmodule Jido.Browser.AgentBrowserRuntimeTest do
 
   describe "runtime helpers" do
     test "find_binary respects configured paths" do
-      with_temporary_script("#!/bin/sh\nexit 0\n", fn binary ->
+      with_temporary_script("#!/bin/sh\nprintf 'agent-browser 0.35.1\\n'\n", fn binary ->
         with_agent_browser_config([binary_path: binary], fn ->
           assert {:ok, ^binary} = Runtime.find_binary()
         end)
       end)
 
       with_agent_browser_config([binary_path: "/missing/agent-browser"], fn ->
-        assert {:error, "Binary not found at /missing/agent-browser"} = Runtime.find_binary()
+        assert {:error, error} = Runtime.find_binary()
+        assert Exception.message(error) == "Configured agent-browser binary was not found"
       end)
     end
 

--- a/test/jido_browser/composite_actions_and_installer_test.exs
+++ b/test/jido_browser/composite_actions_and_installer_test.exs
@@ -402,7 +402,7 @@ defmodule Jido.Browser.CompositeActionsAndInstallerTest do
       end)
 
       with_app_env(:jido_browser, :agent_browser_version, "0.30.0", fn ->
-        assert Installer.configured_version(:agent_browser) == "0.30.0"
+        assert Installer.configured_version(:agent_browser) == "0.35.1"
       end)
 
       with_app_env(:jido_browser, :web_version, nil, fn ->

--- a/test/jido_browser/composite_actions_and_installer_test.exs
+++ b/test/jido_browser/composite_actions_and_installer_test.exs
@@ -488,7 +488,7 @@ defmodule Jido.Browser.CompositeActionsAndInstallerTest do
           "jido_browser_test_agent_browser_#{System.unique_integer([:positive])}"
         )
 
-      File.write!(path, "agent-browser")
+      File.write!(path, "#!/bin/sh\nprintf 'agent-browser 0.35.1\\n'\n")
       File.chmod!(path, 0o755)
 
       try do


### PR DESCRIPTION
## Summary

- Centralize the AgentBrowser 0.35.1 version and validation contract.
- Resolve configured, packaged, and PATH binaries in that exact order.
- Stop on configured-path errors and make runtime and installer use the same compatible binary.
- Keep the public session API and direct daemon transport unchanged.

## Precedence evidence

- Fake-binary tests cover missing, non-executable, unparsable, incompatible, and compatible candidates.
- A compatible package binary wins over an incompatible PATH binary.
- Final local proof used repository package AgentBrowser 0.35.1 with PATH AgentBrowser 0.24.0. Runtime and installer both selected the package binary.

## Test evidence

- First commit direct tests: 37 passed; compile with warnings as errors passed.
- Final focused resolver, runtime, and installer tests: 47 passed.
- Full unit suite: 273 passed, 25 integration tests excluded.
- Coverage gate: 55.3%, above the 53.0% floor.
- Real AgentBrowser 0.35.1 integration suite: 10 passed.
- Quality, documentation, dependency audit, unused-lock, and Hex package checks passed.

Closes #66