### PR TITLE
fix(installer): stop on all browser installation failures

### DIFF
--- a/lib/jido_browser/installer.ex
+++ b/lib/jido_browser/installer.ex
@@ -36,6 +36,11 @@ defmodule Jido.Browser.Installer do
   @vibium_version "26.3.11"
   @web_version "main"
   @lightpanda_version "0.3.0"
+  @command_probes %{
+    vibium: ["version"],
+    web: ["--help"],
+    lightpanda: ["version"]
+  }
 
   @type platform :: :darwin_arm64 | :darwin_amd64 | :linux_amd64 | :linux_arm64 | :windows_amd64
 
@@ -117,17 +122,18 @@ defmodule Jido.Browser.Installer do
   end
 
   def install(:vibium, opts) do
-    install_vibium(opts)
+    verify_effective_install(:vibium, install_vibium(opts), opts)
   end
 
   def install(:web, opts) do
     install_path = opts[:path] || default_install_path()
     force = opts[:force] || false
-    install_web(install_path, force)
+
+    verify_effective_install(:web, install_web(install_path, force), opts)
   end
 
   def install(:lightpanda, opts) do
-    install_lightpanda(opts)
+    verify_effective_install(:lightpanda, install_lightpanda(opts), opts)
   end
 
   @doc """
@@ -183,22 +189,53 @@ defmodule Jido.Browser.Installer do
   defp vibium_installed? do
     case find_vibium_path() do
       nil -> false
-      path -> File.exists?(path)
+      path -> command_usable?(path, @command_probes.vibium)
     end
   end
 
   defp web_installed? do
     case find_web_path() do
       nil -> false
-      path -> File.exists?(path)
+      path -> command_usable?(path, @command_probes.web)
     end
   end
 
   defp lightpanda_installed? do
     case find_lightpanda_path() do
       nil -> false
-      path -> File.exists?(path)
+      path -> command_usable?(path, @command_probes.lightpanda)
     end
+  end
+
+  defp command_usable?(path, args) do
+    match?({_output, 0}, System.cmd(path, args, stderr_to_stdout: true))
+  rescue
+    _error -> false
+  end
+
+  defp verify_effective_install(binary, :ok, opts) do
+    if effective_install_usable?(binary, opts) do
+      :ok
+    else
+      {:error, effective_install_error(binary, bin_path(binary))}
+    end
+  end
+
+  defp verify_effective_install(_binary, result, _opts), do: result
+
+  defp effective_install_usable?(binary, opts) do
+    case configured_path(binary) do
+      path when path not in [nil, ""] -> installed?(binary)
+      _path -> is_binary(opts[:path]) || installed?(binary)
+    end
+  end
+
+  defp effective_install_error(binary, nil) do
+    "#{binary} installation completed, but the selected executable was not found"
+  end
+
+  defp effective_install_error(binary, path) do
+    "#{binary} installation completed, but the selected executable is not usable at #{path}"
   end
 
   defp find_agent_browser_path do
@@ -322,31 +359,49 @@ defmodule Jido.Browser.Installer do
         packages = vibium_npm_packages(configured_version(:vibium))
         Logger.info("Installing vibium via npm...")
 
-        case System.cmd(npm, ["install", "-g" | packages], stderr_to_stdout: true) do
-          {_output, 0} ->
-            stage_vibium_binary()
-            run_vibium_chrome_install()
-            :ok
+        case run_npm_install(npm, packages) do
+          {:ok, {_output, 0}} ->
+            install_staged_vibium()
 
-          {output, code} ->
+          {:ok, {output, code}} ->
             {:error, "npm install failed (exit #{code}): #{output}"}
+
+          {:error, reason} ->
+            {:error, "npm install failed: #{reason}"}
         end
     end
   end
 
-  defp run_vibium_chrome_install do
-    case find_vibium_path() do
-      nil ->
-        Logger.warning("Could not find vibium binary to run browser install")
+  defp run_npm_install(npm, packages) do
+    {:ok, System.cmd(npm, ["install", "-g" | packages], stderr_to_stdout: true)}
+  rescue
+    error -> {:error, Exception.message(error)}
+  end
 
-      vibium ->
-        Logger.info("Installing Chrome for Testing...")
-
-        case System.cmd(vibium, ["install"], stderr_to_stdout: true) do
-          {_output, 0} -> :ok
-          {output, code} -> Logger.warning("Chrome install returned #{code}: #{output}")
+  defp install_staged_vibium do
+    with {:ok, staged, target} <- stage_vibium_binary() do
+      result =
+        with :ok <- run_vibium_chrome_install(staged) do
+          promote_staged_binary(staged, target)
         end
+
+      if result != :ok, do: remove_staged_binary(staged)
+      result
     end
+  end
+
+  defp run_vibium_chrome_install(vibium) do
+    Logger.info("Installing Chrome for Testing...")
+
+    case System.cmd(vibium, ["install"], stderr_to_stdout: true) do
+      {_output, 0} ->
+        :ok
+
+      {output, code} ->
+        {:error, "vibium browser install failed (exit #{code}): #{output}"}
+    end
+  rescue
+    error -> {:error, "vibium browser install failed: #{Exception.message(error)}"}
   end
 
   defp install_agent_browser(install_path, force) do
@@ -363,28 +418,44 @@ defmodule Jido.Browser.Installer do
   end
 
   defp download_and_install_agent_browser(install_path, target) do
-    File.mkdir_p!(install_path)
+    staged = staged_binary_path(target)
     url = agent_browser_download_url()
     Logger.info("Downloading agent-browser from #{url}...")
 
-    with :ok <- download_binary(url, target),
-         :ok <- File.chmod(target, 0o755),
-         {:ok, ^target} <- Binary.validate(target, :package) do
-      run_agent_browser_install(target)
-    end
+    result =
+      with :ok <- ensure_install_directory(install_path),
+           :ok <- prepare_staged_binary(staged),
+           :ok <- download_binary(url, staged),
+           {:ok, ^staged} <- Binary.validate(staged, :package),
+           :ok <- run_agent_browser_install(staged) do
+        promote_staged_binary(staged, target)
+      end
+
+    remove_staged_binary(staged)
+    result
   end
 
   defp install_web(install_path, force) do
     target = Path.join(install_path, web_binary_name())
 
-    if File.exists?(target) and not force do
+    if command_usable?(target, @command_probes.web) and not force do
       Logger.info("web already installed at #{target}. Use --force to overwrite.")
       :ok
     else
-      File.mkdir_p!(install_path)
+      staged = staged_binary_path(target)
       url = web_download_url()
       Logger.info("Downloading web from #{url}...")
-      download_binary(url, target)
+
+      result =
+        with :ok <- ensure_install_directory(install_path),
+             :ok <- prepare_staged_binary(staged),
+             :ok <- download_binary(url, staged),
+             :ok <- ensure_command_usable(staged, @command_probes.web, "downloaded web binary") do
+          promote_staged_binary(staged, target)
+        end
+
+      if result != :ok, do: remove_staged_binary(staged)
+      result
     end
   end
 
@@ -399,13 +470,15 @@ defmodule Jido.Browser.Installer do
   end
 
   defp maybe_install_lightpanda(target, lightpanda_ex, force) do
-    case {File.exists?(target), force} do
+    case {command_usable?(target, @command_probes.lightpanda), force} do
       {true, false} ->
         Logger.info("lightpanda already installed at #{target}. Use --force to overwrite.")
         :ok
 
       _ ->
-        call_lightpanda_ex(lightpanda_ex, :install, [])
+        with :ok <- call_lightpanda_ex(lightpanda_ex, :install, []) do
+          ensure_command_usable(target, @command_probes.lightpanda, "installed lightpanda binary")
+        end
     end
   end
 
@@ -525,6 +598,8 @@ defmodule Jido.Browser.Installer do
       {output, code} ->
         {:error, "agent-browser install failed (exit #{code}): #{output}"}
     end
+  rescue
+    error -> {:error, "agent-browser install failed: #{Exception.message(error)}"}
   end
 
   defp vibium_npm_packages(version) do
@@ -541,18 +616,86 @@ defmodule Jido.Browser.Installer do
   defp stage_vibium_binary do
     case find_vibium_from_npm() do
       nil ->
-        Logger.warning("Could not stage vibium binary after npm install")
+        {:error, "Could not stage vibium binary after npm install: installed command was not found"}
 
       source ->
         target_dir = default_install_path()
         target = Path.join(target_dir, Path.basename(source))
-        File.mkdir_p!(target_dir)
-        File.cp!(source, target)
-        File.chmod!(target, 0o755)
+        staged = staged_binary_path(target)
+
+        result =
+          with :ok <- ensure_install_directory(target_dir),
+               :ok <- prepare_staged_binary(staged),
+               :ok <- copy_staged_binary(source, staged) do
+            {:ok, staged, target}
+          end
+
+        if not match?({:ok, _staged, _target}, result), do: remove_staged_binary(staged)
+        result
     end
-  rescue
-    error ->
-      Logger.warning("Could not stage vibium binary: #{Exception.message(error)}")
+  end
+
+  defp copy_staged_binary(source, staged) do
+    with :ok <- file_result(File.cp(source, staged), "copy vibium binary to #{staged}") do
+      file_result(File.chmod(staged, 0o755), "make vibium binary executable at #{staged}")
+    end
+  end
+
+  defp staged_binary_path(target) do
+    case Path.extname(target) do
+      "" -> target <> ".tmp"
+      extension -> Path.rootname(target, extension) <> ".tmp" <> extension
+    end
+  end
+
+  defp prepare_staged_binary(staged) do
+    case File.rm(staged) do
+      :ok -> :ok
+      {:error, :enoent} -> :ok
+      {:error, reason} -> {:error, file_error("remove old staged binary at #{staged}", reason)}
+    end
+  end
+
+  defp promote_staged_binary(staged, target) do
+    case File.rename(staged, target) do
+      :ok ->
+        :ok
+
+      {:error, :eexist} ->
+        with :ok <- file_result(File.cp(staged, target), "replace binary at #{target}") do
+          file_result(File.rm(staged), "remove promoted staged binary at #{staged}")
+        end
+
+      {:error, reason} ->
+        {:error, file_error("move staged binary to #{target}", reason)}
+    end
+  end
+
+  defp remove_staged_binary(staged) do
+    case File.rm(staged) do
+      :ok -> :ok
+      {:error, :enoent} -> :ok
+      {:error, reason} -> Logger.warning(file_error("remove staged binary at #{staged}", reason))
+    end
+  end
+
+  defp ensure_install_directory(path) do
+    file_result(File.mkdir_p(path), "create install directory at #{path}")
+  end
+
+  defp ensure_command_usable(path, args, label) do
+    if command_usable?(path, args) do
+      :ok
+    else
+      {:error, "#{label} is not usable at #{path}"}
+    end
+  end
+
+  defp file_result(:ok, _action), do: :ok
+  defp file_result({:error, reason}, action), do: {:error, file_error(action, reason)}
+
+  defp file_error(action, reason) do
+    "Could not #{action}: #{reason |> :file.format_error() |> IO.chardata_to_string()}"
   end
 
   defp find_first_existing(candidates, finder) do
@@ -587,10 +730,11 @@ defmodule Jido.Browser.Installer do
   defp download_binary(url, target) do
     case http_download(url) do
       {:ok, body} ->
-        File.write!(target, body)
-        File.chmod!(target, 0o755)
-        Logger.info("✓ Installed to #{target}")
-        :ok
+        with :ok <- file_result(File.write(target, body), "write downloaded binary to #{target}"),
+             :ok <- file_result(File.chmod(target, 0o755), "make downloaded binary executable at #{target}") do
+          Logger.info("✓ Installed to #{target}")
+          :ok
+        end
 
       {:error, reason} ->
         {:error, "Download failed: #{reason}"}

--- a/lib/mix/tasks/jido_browser.install.ex
+++ b/lib/mix/tasks/jido_browser.install.ex
@@ -47,6 +47,14 @@ defmodule Mix.Tasks.JidoBrowser.Install do
 
   alias Jido.Browser.Installer
 
+  @binary_names %{
+    "agent_browser" => :agent_browser,
+    "agent-browser" => :agent_browser,
+    "web" => :web,
+    "vibium" => :vibium,
+    "lightpanda" => :lightpanda
+  }
+
   @impl Mix.Task
   def run(args) do
     {opts, binaries, _} =
@@ -109,7 +117,7 @@ defmodule Mix.Tasks.JidoBrowser.Install do
             Mix.shell().info("✓ #{binary} installed successfully")
 
           {:error, reason} ->
-            Mix.shell().error("✗ Failed to install #{binary}: #{reason}")
+            Mix.raise("Failed to install #{binary}: #{failure_message(reason)}")
         end
     end
 
@@ -117,9 +125,12 @@ defmodule Mix.Tasks.JidoBrowser.Install do
   end
 
   defp install_binary(other, _install_path, _force, _if_missing) do
-    Mix.shell().error("Unknown binary: #{other}. Use 'agent_browser', 'web', 'vibium', or 'lightpanda'.")
+    Mix.raise("Unknown binary: #{other}. Use 'agent_browser', 'web', 'vibium', or 'lightpanda'.")
   end
 
-  defp normalize_binary_name("agent-browser"), do: :agent_browser
-  defp normalize_binary_name(name), do: String.to_atom(name)
+  defp normalize_binary_name(name), do: Map.get(@binary_names, name, name)
+
+  defp failure_message(%{__exception__: true} = reason), do: Exception.message(reason)
+  defp failure_message(reason) when is_binary(reason), do: reason
+  defp failure_message(reason), do: inspect(reason)
 end

--- a/test/jido_browser/composite_actions_and_installer_test.exs
+++ b/test/jido_browser/composite_actions_and_installer_test.exs
@@ -431,7 +431,7 @@ defmodule Jido.Browser.CompositeActionsAndInstallerTest do
 
     test "bin_path/installed? use configured web path when present" do
       path = Path.join(System.tmp_dir!(), "jido_browser_test_web_#{System.unique_integer([:positive])}")
-      File.write!(path, "web")
+      File.write!(path, "#!/bin/sh\nexit 0\n")
       File.chmod!(path, 0o755)
 
       try do
@@ -451,7 +451,7 @@ defmodule Jido.Browser.CompositeActionsAndInstallerTest do
           "jido_browser_test_lightpanda_#{System.unique_integer([:positive])}"
         )
 
-      File.write!(path, "lightpanda")
+      File.write!(path, "#!/bin/sh\nexit 0\n")
       File.chmod!(path, 0o755)
 
       try do
@@ -468,7 +468,7 @@ defmodule Jido.Browser.CompositeActionsAndInstallerTest do
       path =
         Path.join(System.tmp_dir!(), "jido_browser_test_vibium_#{System.unique_integer([:positive])}")
 
-      File.write!(path, "vibium")
+      File.write!(path, "#!/bin/sh\nexit 0\n")
       File.chmod!(path, 0o755)
 
       try do

--- a/test/jido_browser/installer_failure_test.exs
+++ b/test/jido_browser/installer_failure_test.exs
@@ -1,0 +1,462 @@
+defmodule Jido.Browser.InstallerFailureTest do
+  use ExUnit.Case, async: false
+  use Mimic
+
+  alias Jido.Browser.Installer
+
+  setup :set_mimic_global
+
+  setup_all do
+    Mimic.copy(:httpc)
+    :ok
+  end
+
+  setup do
+    directory =
+      Path.join(System.tmp_dir!(), "jido_browser_installer_#{System.unique_integer([:positive])}")
+
+    File.mkdir_p!(directory)
+    on_exit(fn -> File.rm_rf!(directory) end)
+    {:ok, directory: directory}
+  end
+
+  describe "installed?/1" do
+    test "rejects present command shims that return a failure", %{directory: directory} do
+      Enum.each([:vibium, :web, :lightpanda], fn target ->
+        path = write_command(Path.join(directory, Atom.to_string(target)), "exit 19")
+
+        with_app_env(:jido_browser, target, [binary_path: path], fn ->
+          assert Installer.bin_path(target) == path
+          refute Installer.installed?(target)
+        end)
+      end)
+    end
+
+    test "accepts usable commands for all non-AgentBrowser targets", %{directory: directory} do
+      probes = %{vibium: "version", web: "--help", lightpanda: "version"}
+
+      Enum.each(probes, fn {target, probe} ->
+        marker = Path.join(directory, "#{target}-probe")
+
+        path =
+          write_command(
+            Path.join(directory, Atom.to_string(target)),
+            exact_argument_command(probe, marker)
+          )
+
+        with_app_env(:jido_browser, target, [binary_path: path], fn ->
+          assert Installer.bin_path(target) == path
+          assert Installer.installed?(target)
+          assert File.read!(marker) == probe
+        end)
+      end)
+    end
+  end
+
+  describe "AgentBrowser installation" do
+    test "propagates browser-install failure and removes the staged binary", %{directory: directory} do
+      body = """
+      #!/bin/sh
+      case "$1" in
+        --version) printf 'agent-browser 0.35.1\\n'; exit 0 ;;
+        install) printf 'fake runtime failure\\n'; exit 27 ;;
+      esac
+      exit 2
+      """
+
+      expect_http_download(body)
+
+      assert {:error, reason} = Installer.install(:agent_browser, path: directory)
+      assert reason =~ "agent-browser install failed (exit 27)"
+      assert reason =~ "fake runtime failure"
+
+      target = Path.join(directory, agent_browser_binary_name())
+      refute File.exists?(target)
+      refute File.exists?(target <> ".tmp")
+    end
+
+    test "promotes a staged binary after browser installation succeeds", %{directory: directory} do
+      body = """
+      #!/bin/sh
+      case "$1" in
+        --version) printf 'agent-browser 0.35.1\\n'; exit 0 ;;
+        install) exit 0 ;;
+      esac
+      exit 2
+      """
+
+      expect_http_download(body)
+
+      assert :ok = Installer.install(:agent_browser, path: directory)
+
+      target = Path.join(directory, agent_browser_binary_name())
+      assert File.exists?(target)
+      refute File.exists?(target <> ".tmp")
+    end
+
+    test "removes the staged binary when the install command cannot start", %{directory: directory} do
+      body = """
+      #!/bin/sh
+      case "$1" in
+        --version)
+          /bin/chmod 0644 "$0"
+          printf 'agent-browser 0.35.1\\n'
+          exit 0
+          ;;
+      esac
+      exit 2
+      """
+
+      expect_http_download(body)
+
+      assert {:error, reason} = Installer.install(:agent_browser, path: directory)
+      assert reason =~ "agent-browser install failed"
+      assert reason =~ ":eacces"
+
+      target = Path.join(directory, agent_browser_binary_name())
+      refute File.exists?(target)
+      refute File.exists?(target <> ".tmp")
+    end
+  end
+
+  describe "Web installation" do
+    test "propagates download failure and removes the staged binary", %{directory: directory} do
+      expect(:httpc, :request, fn :get, {_url, []}, _http_options, body_format: :binary ->
+        {:error, :fake_offline}
+      end)
+
+      assert {:error, "Download failed: :fake_offline"} = Installer.install(:web, path: directory)
+
+      target = Path.join(directory, web_binary_name())
+      refute File.exists?(target)
+      refute File.exists?(target <> ".tmp")
+    end
+
+    test "rejects and removes an unusable downloaded command", %{directory: directory} do
+      expect_http_download("#!/bin/sh\nexit 31\n")
+
+      assert {:error, reason} = Installer.install(:web, path: directory)
+      assert reason =~ "downloaded web binary is not usable"
+
+      target = Path.join(directory, web_binary_name())
+      refute File.exists?(target)
+      refute File.exists?(target <> ".tmp")
+    end
+
+    test "promotes a usable downloaded command", %{directory: directory} do
+      marker = Path.join(directory, "web-download-probe")
+      expect_http_download("#!/bin/sh\n#{exact_argument_command("--help", marker)}\n")
+
+      assert :ok = Installer.install(:web, path: directory)
+
+      target = Path.join(directory, web_binary_name())
+      assert File.exists?(target)
+      refute File.exists?(target <> ".tmp")
+      assert File.read!(marker) == "--help"
+    end
+
+    test "rejects success when a configured broken command remains selected", %{directory: directory} do
+      configured = write_command(Path.join(directory, "configured-web"), "exit 41")
+      install_path = Path.join(directory, "web-install")
+      expect_http_download("#!/bin/sh\nexit 0\n")
+
+      with_app_env(:jido_browser, :web, [binary_path: configured], fn ->
+        assert {:error, reason} = Installer.install(:web, path: install_path)
+        assert reason =~ "web installation completed"
+        assert reason =~ "selected executable is not usable at #{configured}"
+        refute Installer.installed?(:web)
+        assert command_succeeds?(Path.join(install_path, web_binary_name()), ["--help"])
+      end)
+    end
+  end
+
+  describe "Vibium installation" do
+    test "propagates npm failure", %{directory: directory} do
+      with_fake_vibium_install(directory, [npm_install_status: 17], fn _context ->
+        assert {:error, reason} = Installer.install(:vibium)
+        assert reason =~ "npm install failed (exit 17)"
+      end)
+    end
+
+    test "propagates a missing staged command", %{directory: directory} do
+      with_fake_vibium_install(directory, [source_type: :missing], fn context ->
+        assert {:error, reason} = Installer.install(:vibium)
+        assert reason =~ "Could not stage vibium binary after npm install"
+        refute File.exists?(context.target)
+        refute File.exists?(context.target <> ".tmp")
+      end)
+    end
+
+    test "propagates a staged-command copy failure", %{directory: directory} do
+      with_fake_vibium_install(directory, [source_type: :directory], fn context ->
+        assert {:error, reason} = Installer.install(:vibium)
+        assert reason =~ "Could not copy vibium binary"
+        refute File.exists?(context.target)
+        refute File.exists?(context.target <> ".tmp")
+      end)
+    end
+
+    test "propagates browser-install failure and preserves an earlier target", %{directory: directory} do
+      with_fake_vibium_install(directory, [browser_install_status: 29], fn context ->
+        old_body = "#!/bin/sh\n# earlier target\nexit 0\n"
+        write_command(context.target, "# earlier target\nexit 0")
+
+        assert {:error, reason} = Installer.install(:vibium)
+        assert reason =~ "vibium browser install failed (exit 29)"
+        assert reason =~ "fake browser failure"
+        assert File.read!(context.target) == old_body
+        refute File.exists?(context.target <> ".tmp")
+      end)
+    end
+
+    test "promotes the staged command after all steps succeed", %{directory: directory} do
+      with_fake_vibium_install(directory, [], fn context ->
+        assert :ok = Installer.install(:vibium)
+        assert File.exists?(context.target)
+        refute File.exists?(context.target <> ".tmp")
+        assert Installer.installed?(:vibium)
+      end)
+    end
+
+    test "rejects success when a configured broken command remains selected", %{directory: directory} do
+      with_fake_vibium_install(directory, [], fn context ->
+        configured = write_command(Path.join(directory, "configured-vibium"), "exit 43")
+
+        with_app_env(:jido_browser, :vibium, [binary_path: configured], fn ->
+          assert {:error, reason} = Installer.install(:vibium)
+          assert reason =~ "vibium installation completed"
+          assert reason =~ "selected executable is not usable at #{configured}"
+          refute Installer.installed?(:vibium)
+          assert command_succeeds?(context.target, ["version"])
+        end)
+      end)
+    end
+  end
+
+  describe "Lightpanda installation" do
+    test "propagates install failure and restores LightpandaEx environment", %{directory: directory} do
+      target = Path.join(directory, lightpanda_binary_name())
+
+      with_lightpanda_ex(target, {:error, "fake lightpanda install failure"}, fn ->
+        with_app_env(:lightpanda_ex, :version, "before-version", fn ->
+          with_app_env(:lightpanda_ex, :path, "before-path", fn ->
+            assert {:error, "fake lightpanda install failure"} =
+                     Installer.install(:lightpanda, path: directory, force: true)
+
+            assert Application.get_env(:lightpanda_ex, :version) == "before-version"
+            assert Application.get_env(:lightpanda_ex, :path) == "before-path"
+          end)
+        end)
+      end)
+    end
+
+    test "rejects a successful install that does not create a usable command", %{directory: directory} do
+      target = Path.join(directory, lightpanda_binary_name())
+
+      with_lightpanda_ex(target, :ok, fn ->
+        assert {:error, reason} = Installer.install(:lightpanda, path: directory, force: true)
+        assert reason =~ "installed lightpanda binary is not usable"
+      end)
+    end
+
+    test "keeps successful installation behavior", %{directory: directory} do
+      target = Path.join(directory, lightpanda_binary_name())
+
+      with_lightpanda_ex(target, :create_usable_command, fn ->
+        assert :ok = Installer.install(:lightpanda, path: directory, force: true)
+        assert Installer.installed?(:lightpanda)
+      end)
+    end
+
+    test "rejects success when a configured broken command remains selected", %{directory: directory} do
+      target = Path.join(directory, lightpanda_binary_name())
+      configured = write_command(Path.join(directory, "configured-lightpanda"), "exit 47")
+
+      with_lightpanda_ex(target, :create_usable_command, fn ->
+        with_app_env(:jido_browser, :lightpanda, [binary_path: configured], fn ->
+          assert {:error, reason} = Installer.install(:lightpanda, path: directory, force: true)
+          assert reason =~ "lightpanda installation completed"
+          assert reason =~ "selected executable is not usable at #{configured}"
+          refute Installer.installed?(:lightpanda)
+          assert command_succeeds?(target, ["version"])
+        end)
+      end)
+    end
+  end
+
+  defp expect_http_download(body) do
+    expect(:httpc, :request, fn :get, {_url, []}, _http_options, body_format: :binary ->
+      {:ok, {{~c"HTTP/1.1", 200, ~c"OK"}, [], body}}
+    end)
+  end
+
+  defp with_fake_vibium_install(directory, opts, fun) do
+    command_directory = Path.join(directory, "commands")
+    npm_root = Path.join(directory, "npm-root")
+    install_path = Path.join(directory, "install")
+    package_bin = Path.join([npm_root, vibium_npm_package(), "bin"])
+    source = Path.join(package_bin, vibium_binary_name())
+    target = Path.join(install_path, vibium_binary_name())
+
+    File.mkdir_p!(command_directory)
+    File.mkdir_p!(package_bin)
+
+    case Keyword.get(opts, :source_type, :command) do
+      :command ->
+        browser_status = Keyword.get(opts, :browser_install_status, 0)
+
+        write_command(
+          source,
+          """
+          case "$1" in
+            version) printf 'vibium test\\n'; exit 0 ;;
+            install) printf 'fake browser failure\\n'; exit #{browser_status} ;;
+          esac
+          exit 2
+          """
+        )
+
+      :directory ->
+        File.mkdir_p!(source)
+
+      :missing ->
+        :ok
+    end
+
+    npm_status = Keyword.get(opts, :npm_install_status, 0)
+
+    write_command(
+      Path.join(command_directory, "npm"),
+      """
+      if [ "$1" = "install" ]; then
+        printf 'fake npm install\\n'
+        exit #{npm_status}
+      fi
+      if [ "$1" = "root" ]; then
+        printf '%s\\n' '#{npm_root}'
+        exit 0
+      fi
+      exit 2
+      """
+    )
+
+    with_app_env(:jido_browser, :path, install_path, fn ->
+      with_system_path(command_directory, fn ->
+        fun.(%{source: source, target: target})
+      end)
+    end)
+  end
+
+  defp with_lightpanda_ex(target, install_result, fun) do
+    install_body =
+      case install_result do
+        :create_usable_command ->
+          """
+          File.write!(
+            #{inspect(target)},
+            "#!/bin/sh\\nif [ \\"$#\\" -eq 1 ] && [ \\"$1\\" = \\"version\\" ]; then exit 0; fi\\nexit 97\\n"
+          )
+          File.chmod!(#{inspect(target)}, 0o755)
+          :ok
+          """
+
+        result ->
+          inspect(result)
+      end
+
+    Code.compile_string("""
+    defmodule LightpandaEx do
+      def latest_version, do: "0.3.0"
+      def bin_path, do: #{inspect(target)}
+      def install do
+        #{install_body}
+      end
+    end
+    """)
+
+    try do
+      fun.()
+    after
+      :code.purge(LightpandaEx)
+      :code.delete(LightpandaEx)
+    end
+  end
+
+  defp write_command(path, body) do
+    File.mkdir_p!(Path.dirname(path))
+    File.write!(path, "#!/bin/sh\n#{body}\n")
+    File.chmod!(path, 0o755)
+    path
+  end
+
+  defp command_succeeds?(path, args) do
+    match?({_output, 0}, System.cmd(path, args, stderr_to_stdout: true))
+  end
+
+  defp exact_argument_command(argument, marker) do
+    """
+    if [ "$#" -eq 1 ] && [ "$1" = "#{argument}" ]; then
+      printf '%s' "$1" > '#{marker}'
+      exit 0
+    fi
+    exit 97
+    """
+  end
+
+  defp with_app_env(app, key, value, fun) do
+    previous = Application.get_env(app, key, :__missing__)
+    Application.put_env(app, key, value)
+
+    try do
+      fun.()
+    after
+      restore_app_env(app, key, previous)
+    end
+  end
+
+  defp restore_app_env(app, key, :__missing__), do: Application.delete_env(app, key)
+  defp restore_app_env(app, key, value), do: Application.put_env(app, key, value)
+
+  defp with_system_path(directory, fun) do
+    previous = System.get_env("PATH")
+    System.put_env("PATH", directory)
+
+    try do
+      fun.()
+    after
+      if previous, do: System.put_env("PATH", previous), else: System.delete_env("PATH")
+    end
+  end
+
+  defp agent_browser_binary_name do
+    case Installer.target() do
+      :darwin_arm64 -> "agent-browser-darwin-arm64"
+      :darwin_amd64 -> "agent-browser-darwin-x64"
+      :linux_amd64 -> "agent-browser-linux-x64"
+      :linux_arm64 -> "agent-browser-linux-arm64"
+      :windows_amd64 -> "agent-browser-win32-x64.exe"
+    end
+  end
+
+  defp web_binary_name do
+    if Installer.target() == :windows_amd64, do: "web.exe", else: "web"
+  end
+
+  defp lightpanda_binary_name do
+    if Installer.target() == :windows_amd64, do: "lightpanda.exe", else: "lightpanda"
+  end
+
+  defp vibium_npm_package do
+    case Installer.target() do
+      :darwin_arm64 -> "@vibium/darwin-arm64"
+      :darwin_amd64 -> "@vibium/darwin-x64"
+      :linux_amd64 -> "@vibium/linux-x64"
+      :linux_arm64 -> "@vibium/linux-arm64"
+      :windows_amd64 -> "@vibium/win32-x64"
+    end
+  end
+
+  defp vibium_binary_name do
+    if Installer.target() == :windows_amd64, do: "vibium.exe", else: "vibium"
+  end
+end

--- a/test/jido_browser/mix_task_install_test.exs
+++ b/test/jido_browser/mix_task_install_test.exs
@@ -1,0 +1,113 @@
+defmodule Jido.Browser.MixTaskInstallTest do
+  use ExUnit.Case, async: false
+  use Mimic
+
+  alias Jido.Browser.Error
+  alias Jido.Browser.Installer
+  alias Mix.Tasks.JidoBrowser.Install, as: InstallTask
+
+  setup :set_mimic_global
+
+  setup_all do
+    Mimic.copy(Installer)
+    :ok
+  end
+
+  setup do
+    directory =
+      Path.join(System.tmp_dir!(), "jido_browser_mix_task_#{System.unique_integer([:positive])}")
+
+    File.mkdir_p!(directory)
+    on_exit(fn -> File.rm_rf!(directory) end)
+    {:ok, directory: directory}
+  end
+
+  test "accepts every supported target name and the agent-browser alias" do
+    targets = [
+      {"agent_browser", :agent_browser},
+      {"agent-browser", :agent_browser},
+      {"web", :web},
+      {"vibium", :vibium},
+      {"lightpanda", :lightpanda}
+    ]
+
+    Enum.each(targets, fn {name, target} ->
+      expect(Installer, :installed?, fn ^target -> true end)
+      expect(Installer, :bin_path, fn ^target -> "/fake/#{target}" end)
+
+      assert :ok = InstallTask.run(["--if-missing", name])
+    end)
+  end
+
+  test "raises for unknown input without creating an atom" do
+    name = "unknown_target_#{System.unique_integer([:positive])}"
+
+    assert_raise ArgumentError, fn -> String.to_existing_atom(name) end
+
+    assert_raise Mix.Error,
+                 "Unknown binary: #{name}. Use 'agent_browser', 'web', 'vibium', or 'lightpanda'.",
+                 fn -> InstallTask.run([name]) end
+
+    assert_raise ArgumentError, fn -> String.to_existing_atom(name) end
+  end
+
+  test "raises with the target-specific reason for every failed installer" do
+    failures = [
+      {:agent_browser, Error.adapter_error("fake AgentBrowser failure")},
+      {:web, "fake web failure"},
+      {:vibium, {:npm_exit, 17}},
+      {:lightpanda, "fake Lightpanda failure"}
+    ]
+
+    Enum.each(failures, fn {target, reason} ->
+      expect(Installer, :installed?, fn ^target -> false end)
+
+      expect(Installer, :install, fn ^target, opts ->
+        assert opts == [force: false]
+        {:error, reason}
+      end)
+
+      expected = "Failed to install #{target}: #{failure_message(reason)}"
+
+      assert_raise Mix.Error, expected, fn ->
+        InstallTask.run([Atom.to_string(target)])
+      end
+    end)
+  end
+
+  test "keeps successful installation behavior" do
+    expect(Installer, :installed?, fn :web -> false end)
+
+    expect(Installer, :install, fn :web, opts ->
+      assert opts == [path: "/fake/install", force: true]
+      :ok
+    end)
+
+    assert :ok = InstallTask.run(["--path", "/fake/install", "--force", "web"])
+  end
+
+  test "a failed installation command exits with a nonzero status", %{directory: directory} do
+    missing = Path.join(directory, "missing-agent-browser")
+
+    expression = """
+    Application.put_env(:jido_browser, :agent_browser, binary_path: #{inspect(missing)})
+    Mix.Task.run("jido_browser.install", ["agent_browser"])
+    """
+
+    {output, status} =
+      System.cmd(
+        System.find_executable("mix"),
+        ["run", "--no-compile", "--no-start", "-e", expression],
+        cd: File.cwd!(),
+        env: [{"MIX_ENV", "test"}],
+        stderr_to_stdout: true
+      )
+
+    assert status != 0
+    assert output =~ "Failed to install agent_browser: Configured agent-browser binary was not found"
+  end
+
+  defp failure_message(%{__exception__: true} = reason), do: Exception.message(reason)
+  defp failure_message(reason) when is_binary(reason), do: reason
+  defp failure_message(reason), do: inspect(reason)
+end


### PR DESCRIPTION
## Summary

- replace user-driven atom creation with a fixed map for `agent_browser`, `agent-browser`, `web`, `vibium`, and `lightpanda`
- raise `Mix.Error` for unknown targets and installer errors so the Mix command returns a nonzero status
- propagate Vibium npm, staging, and browser-install failures with exit status and output
- reject unusable Vibium, Web, and Lightpanda command shims with target-specific probes
- require the effective selected non-AgentBrowser command to be usable after a successful install step when an explicit command path controls selection
- stage AgentBrowser, Web, and Vibium binaries and remove AgentBrowser staged files after success, nonzero exit, or command-start exception
- preserve the AgentBrowser resolver version and configured/package/PATH precedence from #66

Closes #64

## Failure-semantic evidence

- Installer tests use fake local commands and temporary paths. They cover AgentBrowser browser-install nonzero exit and command-start exception, Web download and unusable-command failure, Vibium npm/staging/browser-install failure, and Lightpanda install and post-install validation failure.
- Configured-path regression tests cover Vibium, Web, and Lightpanda. Each test installs a usable command elsewhere, keeps the broken configured command authoritative, and verifies that `install/2` returns an error instead of false success.
- AgentBrowser cleanup assertions cover successful promotion, nonzero browser-install exit, and an `:eacces` command-start exception after version validation. No staged file remains in any case.
- Non-AgentBrowser success shims accept only the required probe: Vibium `version`, Web `--help`, and Lightpanda `version`.
- Mix task tests cover every supported target name, the `agent-browser` alias, unknown input without atom creation, and target-specific installer errors.
- A child `mix` process test verifies that a failed AgentBrowser installation returns a nonzero command status and keeps the resolver exception message.
- Tests restore application environment and `PATH` after each fake-command case.

## Test evidence

- `mix test test/jido_browser/installer_failure_test.exs test/jido_browser/mix_task_install_test.exs test/jido_browser/agent_browser_binary_test.exs test/jido_browser/composite_actions_and_installer_test.exs` — 60 passed
- amended first commit alone — compiled and 55 direct tests passed
- `mix coveralls` — 297 passed, 25 excluded, 60.1% total coverage
- `mix compile --warnings-as-errors` — passed
- `mix format --check-formatted` — passed
- `mix quality` — passed with 0 Dialyzer errors and 100% Doctor documentation/spec coverage
- `mix docs -f html` — passed
- `mix hex.audit` — no retired or vulnerable packages
- `mix hex.build --unpack` — passed; installer and Mix task files verified in the package
