### PR TITLE
ci(agent_browser): require the supported smoke suite

### DIFF
--- a/.github/scripts/cleanup-agent-browser.sh
+++ b/.github/scripts/cleanup-agent-browser.sh
@@ -1,0 +1,403 @@
+#!/usr/bin/env bash
+
+set -uo pipefail
+
+job_root="${AGENT_BROWSER_JOB_ROOT:-}"
+socket_dir="${AGENT_BROWSER_SOCKET_DIR:-}"
+agent_browser_binary="${AGENT_BROWSER_BINARY:-}"
+chromium_executables="${AGENT_BROWSER_CHROMIUM_EXECUTABLES:-}"
+runner_temp="${RUNNER_TEMP:-}"
+test_executables="${AGENT_BROWSER_CLEANUP_TEST_EXECUTABLES:-}"
+cleanup_failed=0
+
+if [[ -z "$job_root" ]]; then
+  echo "AgentBrowser runtime root was not prepared; there is nothing to clean."
+  exit 0
+fi
+
+case "$job_root" in
+  /*/jido-ab.*) ;;
+  *)
+    echo "Refusing to clean an invalid AgentBrowser runtime root: $job_root" >&2
+    exit 1
+    ;;
+esac
+
+if [[ -z "$runner_temp" || "$job_root" != "$runner_temp"/* ]]; then
+  echo "AgentBrowser runtime root is not under RUNNER_TEMP: $job_root" >&2
+  exit 1
+fi
+
+if [[ "$socket_dir" != "$job_root/socket" ]]; then
+  echo "AgentBrowser socket directory is outside the runtime root: $socket_dir" >&2
+  exit 1
+fi
+
+if [[ ! -r /proc/self/stat ]]; then
+  echo "Exact AgentBrowser process cleanup requires Linux /proc." >&2
+  exit 1
+fi
+
+marker_path="$job_root/.jido-browser-agent-browser-root"
+marker_valid=0
+
+if [[ -f "$marker_path" ]]; then
+  IFS= read -r marker_root < "$marker_path" || true
+
+  if [[ "${marker_root:-}" == "$job_root" ]]; then
+    marker_valid=1
+  fi
+elif [[ ! -e "$job_root" && ! -L "$job_root" ]]; then
+  marker_valid=1
+fi
+
+if [[ "$marker_valid" -ne 1 ]]; then
+  echo "AgentBrowser runtime root has no valid cleanup marker: $job_root" >&2
+  cleanup_failed=1
+fi
+
+read_process_stat_field() {
+  local process_pid="$1"
+  local field="$2"
+  local stat_line
+  local stat_rest
+  local stat_fields
+
+  IFS= read -r stat_line 2>/dev/null < "/proc/$process_pid/stat" || return 1
+  stat_rest="${stat_line##*) }"
+  read -r -a stat_fields <<< "$stat_rest"
+
+  case "$field" in
+    ppid)
+      [[ "${#stat_fields[@]}" -ge 2 ]] || return 1
+      printf '%s\n' "${stat_fields[1]}"
+      ;;
+    start_time)
+      [[ "${#stat_fields[@]}" -ge 20 ]] || return 1
+      printf '%s\n' "${stat_fields[19]}"
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+excluded_records=()
+ancestor_pid="$$"
+
+while [[ "$ancestor_pid" =~ ^[0-9]+$ && "$ancestor_pid" -gt 0 ]]; do
+  ancestor_start="$(read_process_stat_field "$ancestor_pid" start_time 2>/dev/null || true)"
+
+  if [[ -n "$ancestor_start" ]]; then
+    excluded_records+=("$ancestor_pid:$ancestor_start")
+  fi
+
+  ancestor_pid="$(read_process_stat_field "$ancestor_pid" ppid 2>/dev/null || true)"
+done
+
+is_excluded_record() {
+  local candidate_record="$1"
+  local excluded_record
+
+  for excluded_record in "${excluded_records[@]}"; do
+    if [[ "$candidate_record" == "$excluded_record" ]]; then
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+agent_browser_executable_id=""
+chromium_executable_ids=()
+test_executable_ids=()
+
+executable_id_for_path() {
+  local executable_path="$1"
+
+  [[ -n "$executable_path" && -x "$executable_path" ]] || return 1
+  stat -Lc '%d:%i' -- "$executable_path" 2>/dev/null
+}
+
+add_unique_executable_id() {
+  local executable_id="$1"
+  local array_name="$2"
+  local existing_id
+
+  declare -n executable_ids_ref="$array_name"
+
+  for existing_id in "${executable_ids_ref[@]}"; do
+    if [[ "$existing_id" == "$executable_id" ]]; then
+      return 0
+    fi
+  done
+
+  executable_ids_ref+=("$executable_id")
+}
+
+agent_browser_executable_id="$(executable_id_for_path "$agent_browser_binary" 2>/dev/null || true)"
+
+if [[ -n "$chromium_executables" ]]; then
+  IFS=: read -r -a configured_chromium_executables <<< "$chromium_executables"
+
+  for chromium_executable in "${configured_chromium_executables[@]}"; do
+    chromium_executable_id="$(executable_id_for_path "$chromium_executable" 2>/dev/null || true)"
+
+    if [[ -n "$chromium_executable_id" ]]; then
+      add_unique_executable_id "$chromium_executable_id" chromium_executable_ids
+    fi
+  done
+fi
+
+if [[ -n "$test_executables" ]]; then
+  IFS=: read -r -a extra_executables <<< "$test_executables"
+
+  for extra_executable in "${extra_executables[@]}"; do
+    extra_executable_id="$(executable_id_for_path "$extra_executable" 2>/dev/null || true)"
+
+    if [[ -n "$extra_executable_id" ]]; then
+      add_unique_executable_id "$extra_executable_id" test_executable_ids
+    fi
+  done
+fi
+
+path_is_inside_job_root() {
+  local candidate_path="$1"
+
+  [[ "$candidate_path" == "$job_root" || "$candidate_path" == "$job_root/"* ]]
+}
+
+process_has_exact_job_root_environment() {
+  local process_pid="$1"
+  local entry
+
+  if [[ -r "/proc/$process_pid/environ" ]]; then
+    while IFS= read -r -d '' entry; do
+      if [[ "$entry" == "AGENT_BROWSER_JOB_ROOT=$job_root" ]]; then
+        return 0
+      fi
+    done 2>/dev/null < "/proc/$process_pid/environ" || true
+  fi
+
+  return 1
+}
+
+process_has_job_root_profile_argument() {
+  local process_pid="$1"
+  local entry
+  local option_value
+  local next_entry_is_profile=0
+
+  if [[ -r "/proc/$process_pid/cmdline" ]]; then
+    while IFS= read -r -d '' entry; do
+      if [[ "$next_entry_is_profile" -eq 1 ]]; then
+        path_is_inside_job_root "$entry"
+        return
+      fi
+
+      case "$entry" in
+        --user-data-dir)
+          next_entry_is_profile=1
+          ;;
+        --user-data-dir=*)
+          option_value="${entry#--user-data-dir=}"
+
+          if path_is_inside_job_root "$option_value"; then
+            return 0
+          fi
+          ;;
+      esac
+    done 2>/dev/null < "/proc/$process_pid/cmdline" || true
+  fi
+
+  return 1
+}
+
+validated_executable_kind=""
+
+process_has_trusted_executable() {
+  local process_pid="$1"
+  local executable_id
+  local allowed_id
+
+  validated_executable_kind=""
+  executable_id="$(stat -Lc '%d:%i' -- "/proc/$process_pid/exe" 2>/dev/null)" || return 1
+
+  if [[ -n "$agent_browser_executable_id" &&
+        "$executable_id" == "$agent_browser_executable_id" ]]; then
+    validated_executable_kind="agent_browser"
+    return 0
+  fi
+
+  for allowed_id in "${chromium_executable_ids[@]}"; do
+    if [[ "$executable_id" == "$allowed_id" ]]; then
+      validated_executable_kind="chromium"
+      return 0
+    fi
+  done
+
+  for allowed_id in "${test_executable_ids[@]}"; do
+    if [[ "$executable_id" == "$allowed_id" ]]; then
+      validated_executable_kind="test"
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+validated_start_time=""
+
+process_identity_is_owned() {
+  local process_pid="$1"
+  local expected_start_time="$2"
+  local start_time_before
+  local start_time_after
+
+  validated_start_time=""
+  start_time_before="$(read_process_stat_field "$process_pid" start_time 2>/dev/null)" || return 1
+
+  if [[ -n "$expected_start_time" && "$start_time_before" != "$expected_start_time" ]]; then
+    return 1
+  fi
+
+  process_has_exact_job_root_environment "$process_pid" || return 1
+  process_has_trusted_executable "$process_pid" || return 1
+
+  if [[ "$validated_executable_kind" == "chromium" ]]; then
+    process_has_job_root_profile_argument "$process_pid" || return 1
+  fi
+
+  start_time_after="$(read_process_stat_field "$process_pid" start_time 2>/dev/null)" || return 1
+
+  if [[ "$start_time_before" != "$start_time_after" ]]; then
+    return 1
+  fi
+
+  validated_start_time="$start_time_after"
+  return 0
+}
+
+owned_records=()
+
+discover_owned_processes() {
+  local process_path
+  local process_pid
+  local process_start_time
+  local process_record
+
+  owned_records=()
+
+  for process_path in /proc/[0-9]*; do
+    process_pid="${process_path#/proc/}"
+    process_start_time="$(read_process_stat_field "$process_pid" start_time 2>/dev/null || true)"
+
+    if [[ -z "$process_start_time" ]]; then
+      continue
+    fi
+
+    process_record="$process_pid:$process_start_time"
+
+    if is_excluded_record "$process_record"; then
+      continue
+    fi
+
+    if process_identity_is_owned "$process_pid" "$process_start_time"; then
+      owned_records+=("$process_pid:$validated_start_time")
+    fi
+  done
+}
+
+signal_owned_record() {
+  local process_record="$1"
+  local signal_name="$2"
+  local process_pid="${process_record%%:*}"
+  local expected_start_time="${process_record#*:}"
+  if is_excluded_record "$process_record"; then
+    return 1
+  fi
+
+  if ! process_identity_is_owned "$process_pid" "$expected_start_time"; then
+    return 1
+  fi
+
+  kill -s "$signal_name" "$process_pid" 2>/dev/null
+}
+
+signal_owned_processes() {
+  local signal_name="$1"
+  local process_record
+  local signaled_records=()
+
+  for process_record in "${owned_records[@]}"; do
+    if signal_owned_record "$process_record" "$signal_name"; then
+      signaled_records+=("$process_record")
+    fi
+  done
+
+  if [[ "${#signaled_records[@]}" -gt 0 ]]; then
+    echo "Sent $signal_name to verified job-owned processes: ${signaled_records[*]}"
+  fi
+}
+
+wait_for_owned_processes_to_exit() {
+  local wait_seconds="$1"
+  local deadline=$((SECONDS + wait_seconds))
+
+  while ((SECONDS < deadline)); do
+    discover_owned_processes
+
+    if [[ "${#owned_records[@]}" -eq 0 ]]; then
+      return 0
+    fi
+
+    sleep 0.1
+  done
+
+  discover_owned_processes
+  [[ "${#owned_records[@]}" -eq 0 ]]
+}
+
+cleanup_agent_browser() {
+  discover_owned_processes
+  signal_owned_processes TERM
+
+  if ! wait_for_owned_processes_to_exit 3; then
+    echo "Verified job-owned processes did not exit during the bounded TERM wait."
+  fi
+
+  discover_owned_processes
+  signal_owned_processes KILL
+
+  if ! wait_for_owned_processes_to_exit 2; then
+    echo "Verified job-owned processes remain after the bounded KILL wait." >&2
+    cleanup_failed=1
+  fi
+
+  if [[ "$marker_valid" -eq 1 && ( -e "$job_root" || -L "$job_root" ) ]]; then
+    rm -rf -- "$job_root" || cleanup_failed=1
+  fi
+
+  discover_owned_processes
+
+  if [[ "${#owned_records[@]}" -gt 0 ]]; then
+    echo "Verified job-owned processes remain: ${owned_records[*]}" >&2
+    cleanup_failed=1
+  fi
+
+  if [[ -e "$job_root" || -L "$job_root" ]]; then
+    echo "AgentBrowser runtime artifacts remain under: $job_root" >&2
+    cleanup_failed=1
+  fi
+
+  if [[ "$cleanup_failed" -eq 0 ]]; then
+    echo "Verified AgentBrowser processes and runtime artifacts were removed."
+  fi
+
+  return "$cleanup_failed"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  cleanup_agent_browser
+  exit $?
+fi

--- a/.github/scripts/test-agent-browser-cleanup.sh
+++ b/.github/scripts/test-agent-browser-cleanup.sh
@@ -1,0 +1,386 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ ! -r /proc/self/stat ]]; then
+  echo "Forced cleanup harness requires Linux /proc; skipping on this host."
+  exit 0
+fi
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cleanup_script="$script_dir/cleanup-agent-browser.sh"
+official_binary="${AGENT_BROWSER_BINARY:-}"
+real_chromium_binary="${AGENT_BROWSER_CHROMIUM_BINARY:-}"
+chromium_executables="${AGENT_BROWSER_CHROMIUM_EXECUTABLES:-}"
+harness_runner_temp="$(mktemp -d "${RUNNER_TEMP:-${TMPDIR:-/tmp}}/jido-cleanup.XXXXXX")"
+job_root="$(mktemp -d "$harness_runner_temp/jido-ab.XXXXXX")"
+socket_dir="$job_root/socket"
+profile_dir="$job_root/tmp/agent-browser-chrome-harness"
+orphan_pid_path="$harness_runner_temp/orphan.pid"
+orphan_launcher_pid_path="$harness_runner_temp/orphan-launcher.pid"
+tail_path="$(readlink -f "$(command -v tail)")"
+fake_chrome_dir="$harness_runner_temp/jido-fake-bin"
+fake_chrome_path="$fake_chrome_dir/chrome"
+control_pid=""
+prefix_control_pid=""
+fake_chrome_pid=""
+crashed_daemon_pid=""
+live_daemon_pid=""
+identity_probe_pid=""
+orphan_chrome_pid=""
+
+read_process_start_time() {
+  local process_pid="$1"
+  local stat_line
+  local stat_rest
+  local stat_fields
+
+  IFS= read -r stat_line < "/proc/$process_pid/stat"
+  stat_rest="${stat_line##*) }"
+  read -r -a stat_fields <<< "$stat_rest"
+  printf '%s\n' "${stat_fields[19]}"
+}
+
+process_is_running() {
+  local process_pid="$1"
+  local process_state
+
+  kill -0 "$process_pid" 2>/dev/null || return 1
+  process_state="$(ps -o stat= -p "$process_pid" 2>/dev/null || true)"
+  [[ -n "$process_state" && "$process_state" != Z* ]]
+}
+
+process_uses_trusted_chromium_identity() {
+  local process_pid="$1"
+  local process_executable_id
+  local executable_path
+  local configured_executable_id
+
+  process_executable_id="$(stat -Lc '%d:%i' -- "/proc/$process_pid/exe" 2>/dev/null)" || return 1
+  IFS=: read -r -a configured_executables <<< "$chromium_executables"
+
+  for executable_path in "${configured_executables[@]}"; do
+    configured_executable_id="$(stat -Lc '%d:%i' -- "$executable_path" 2>/dev/null || true)"
+
+    if [[ -n "$configured_executable_id" &&
+          "$process_executable_id" == "$configured_executable_id" ]]; then
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+finish() {
+  local exit_status="$?"
+  local process_pid
+
+  trap - EXIT
+
+  if [[ -f "$job_root/.jido-browser-agent-browser-root" ]]; then
+    RUNNER_TEMP="$harness_runner_temp" \
+    AGENT_BROWSER_JOB_ROOT="$job_root" \
+    AGENT_BROWSER_SOCKET_DIR="$socket_dir" \
+    AGENT_BROWSER_BINARY="$official_binary" \
+    AGENT_BROWSER_CHROMIUM_EXECUTABLES="$chromium_executables" \
+    AGENT_BROWSER_CLEANUP_TEST_EXECUTABLES="$tail_path" \
+      bash "$cleanup_script" >/dev/null 2>&1 || true
+  fi
+
+  for process_pid in \
+    "$control_pid" \
+    "$prefix_control_pid" \
+    "$fake_chrome_pid" \
+    "$crashed_daemon_pid" \
+    "$live_daemon_pid" \
+    "$identity_probe_pid" \
+    "$orphan_chrome_pid"; do
+    if [[ -n "$process_pid" ]]; then
+      kill -KILL "$process_pid" 2>/dev/null || true
+      wait "$process_pid" 2>/dev/null || true
+    fi
+  done
+
+  rm -rf -- "$harness_runner_temp"
+  exit "$exit_status"
+}
+
+trap finish EXIT
+
+if [[ ! -x "$official_binary" ]]; then
+  echo "The official AgentBrowser binary is required by the cleanup harness." >&2
+  exit 1
+fi
+
+detected_version="$("$official_binary" --version)"
+
+if [[ "$detected_version" != "agent-browser 0.35.1" ]]; then
+  echo "Expected official AgentBrowser 0.35.1, got: $detected_version" >&2
+  exit 1
+fi
+
+if [[ ! -x "$real_chromium_binary" || -z "$chromium_executables" ]]; then
+  echo "A trusted real Chromium binary and executable identity list are required." >&2
+  exit 1
+fi
+
+real_chromium_version="$($real_chromium_binary --version)"
+
+case "$real_chromium_version" in
+  *Chrome*|*Chromium*) ;;
+  *)
+    echo "Expected a real Chromium executable, got: $real_chromium_version" >&2
+    exit 1
+    ;;
+esac
+
+mkdir -p "$socket_dir" "$profile_dir/Default" "$fake_chrome_dir"
+printf '%s\n' "$job_root" > "$job_root/.jido-browser-agent-browser-root"
+
+for suffix in version sock stream engine provider extensions; do
+  printf 'remaining session artifact\n' > "$socket_dir/forced-cleanup.$suffix"
+done
+
+printf 'remaining Chrome profile\n' > "$profile_dir/Default/Preferences"
+printf 'unrelated input\n' > "$job_root/unrelated-input"
+
+cp -- "$tail_path" "$fake_chrome_path"
+chmod 700 "$fake_chrome_path"
+
+env -u AGENT_BROWSER_JOB_ROOT -u AGENT_BROWSER_SOCKET_DIR sleep 300 &
+control_pid="$!"
+printf '%s\n' "$control_pid" > "$socket_dir/stale.pid"
+
+# shellcheck disable=SC2016
+env -u AGENT_BROWSER_JOB_ROOT -u AGENT_BROWSER_SOCKET_DIR \
+  bash -c 'exec -a "$1/chrome --user-data-dir=$1/profile" sleep 300' _ "${job_root}-other" &
+prefix_control_pid="$!"
+
+env -u AGENT_BROWSER_JOB_ROOT -u AGENT_BROWSER_SOCKET_DIR \
+  "$fake_chrome_path" -f "$job_root/unrelated-input" >/dev/null &
+fake_chrome_pid="$!"
+
+env \
+  AGENT_BROWSER_JOB_ROOT="$job_root" \
+  AGENT_BROWSER_SOCKET_DIR="$socket_dir" \
+  bash -c 'exec -a agent-browser-crashed tail -f /dev/null' &
+crashed_daemon_pid="$!"
+printf '%s\n' "$crashed_daemon_pid" > "$socket_dir/crashed.pid"
+kill -KILL "$crashed_daemon_pid"
+wait "$crashed_daemon_pid" 2>/dev/null || true
+
+env \
+  AGENT_BROWSER_JOB_ROOT="$job_root" \
+  AGENT_BROWSER_SOCKET_DIR="$socket_dir" \
+  AGENT_BROWSER_SESSION="cleanup-harness" \
+  AGENT_BROWSER_DAEMON=1 \
+  "$official_binary" >"$job_root/official-daemon.log" 2>&1 &
+live_daemon_pid="$!"
+
+for _attempt in {1..100}; do
+  if [[ -S "$socket_dir/cleanup-harness.sock" ]]; then
+    break
+  fi
+
+  kill -0 "$live_daemon_pid" 2>/dev/null || break
+  sleep 0.02
+done
+
+if [[ ! -S "$socket_dir/cleanup-harness.sock" ]]; then
+  echo "Official AgentBrowser daemon did not become ready." >&2
+  sed -n '1,120p' "$job_root/official-daemon.log" >&2
+  exit 1
+fi
+
+env \
+  AGENT_BROWSER_JOB_ROOT="$job_root" \
+  AGENT_BROWSER_SOCKET_DIR="$socket_dir" \
+  bash -c 'exec -a identity-record-probe tail -f /dev/null' &
+identity_probe_pid="$!"
+identity_probe_start_time="$(read_process_start_time "$identity_probe_pid")"
+wrong_identity_probe_start_time="$((identity_probe_start_time + 1))"
+
+RUNNER_TEMP="$harness_runner_temp" \
+AGENT_BROWSER_JOB_ROOT="$job_root" \
+AGENT_BROWSER_SOCKET_DIR="$socket_dir" \
+AGENT_BROWSER_BINARY="$official_binary" \
+AGENT_BROWSER_CHROMIUM_EXECUTABLES="$chromium_executables" \
+AGENT_BROWSER_CLEANUP_TEST_EXECUTABLES="$tail_path" \
+  bash -c '
+    source "$1"
+
+    if signal_owned_record "$2:$3" TERM; then
+      echo "A stale PID:start_time record was accepted." >&2
+      exit 1
+    fi
+
+    kill -0 "$2"
+    signal_owned_record "$2:$4" TERM
+  ' _ "$cleanup_script" "$identity_probe_pid" \
+    "$wrong_identity_probe_start_time" "$identity_probe_start_time"
+
+wait "$identity_probe_pid" 2>/dev/null || true
+
+if kill -0 "$identity_probe_pid" 2>/dev/null; then
+  echo "The correct PID:start_time record was not handled." >&2
+  exit 1
+fi
+
+identity_probe_pid=""
+
+# shellcheck disable=SC2016
+env \
+  AGENT_BROWSER_JOB_ROOT="$job_root" \
+  AGENT_BROWSER_SOCKET_DIR="$socket_dir" \
+  CHROMIUM_BINARY="$real_chromium_binary" \
+  PROFILE_DIR="$profile_dir" \
+  ORPHAN_PID_PATH="$orphan_pid_path" \
+  ORPHAN_LAUNCHER_PID_PATH="$orphan_launcher_pid_path" \
+  bash -c '
+    printf "%s\n" "$$" > "$ORPHAN_LAUNCHER_PID_PATH"
+    "$CHROMIUM_BINARY" \
+      --headless=new \
+      --no-sandbox \
+      --disable-background-networking \
+      --disable-dev-shm-usage \
+      --disable-gpu \
+      --no-first-run \
+      --remote-debugging-port=0 \
+      "--user-data-dir=$PROFILE_DIR" \
+      about:blank >"$PROFILE_DIR/chromium.log" 2>&1 &
+    printf "%s\n" "$!" > "$ORPHAN_PID_PATH"
+  '
+
+for _attempt in {1..50}; do
+  if [[ -s "$orphan_pid_path" ]]; then
+    break
+  fi
+
+  sleep 0.02
+done
+
+IFS= read -r orphan_chrome_pid < "$orphan_pid_path"
+IFS= read -r orphan_launcher_pid < "$orphan_launcher_pid_path"
+
+for _attempt in {1..100}; do
+  if kill -0 "$orphan_chrome_pid" 2>/dev/null &&
+      process_uses_trusted_chromium_identity "$orphan_chrome_pid"; then
+    break
+  fi
+
+  sleep 0.02
+done
+
+if ! process_uses_trusted_chromium_identity "$orphan_chrome_pid"; then
+  echo "Real Chromium did not start with a configured trusted identity." >&2
+  sed -n '1,120p' "$profile_dir/chromium.log" >&2
+  exit 1
+fi
+
+kill -STOP "$orphan_chrome_pid"
+orphan_chrome_start_time="$(read_process_start_time "$orphan_chrome_pid")"
+orphan_chrome_record="$orphan_chrome_pid:$orphan_chrome_start_time"
+
+for _attempt in {1..50}; do
+  orphan_state="$(ps -o stat= -p "$orphan_chrome_pid" 2>/dev/null || true)"
+
+  if [[ "$orphan_state" == T* ]]; then
+    break
+  fi
+
+  sleep 0.02
+done
+
+kill -0 "$live_daemon_pid"
+kill -0 "$orphan_chrome_pid"
+kill -0 "$control_pid"
+kill -0 "$prefix_control_pid"
+kill -0 "$fake_chrome_pid"
+
+orphan_parent_pid="$(ps -o ppid= -p "$orphan_chrome_pid")"
+orphan_parent_pid="${orphan_parent_pid//[[:space:]]/}"
+
+if [[ "$orphan_parent_pid" == "$orphan_launcher_pid" || "$orphan_state" != T* ]]; then
+  echo "Chrome harness process was not stopped and reparented." >&2
+  exit 1
+fi
+
+cleanup_shell_parent_pid="$$"
+cleanup_started_ns="$(date +%s%N)"
+cleanup_status=0
+
+cleanup_output="$(
+  RUNNER_TEMP="$harness_runner_temp" \
+  AGENT_BROWSER_JOB_ROOT="$job_root" \
+  AGENT_BROWSER_SOCKET_DIR="$socket_dir" \
+  AGENT_BROWSER_BINARY="$official_binary" \
+  AGENT_BROWSER_CHROMIUM_EXECUTABLES="$chromium_executables" \
+  AGENT_BROWSER_CLEANUP_TEST_EXECUTABLES="$tail_path" \
+    bash "$cleanup_script"
+)" || cleanup_status=$?
+
+cleanup_finished_ns="$(date +%s%N)"
+cleanup_elapsed_ms="$(((cleanup_finished_ns - cleanup_started_ns) / 1000000))"
+printf '%s\n' "$cleanup_output"
+
+if [[ "$cleanup_status" -ne 0 ]]; then
+  echo "Forced cleanup returned status $cleanup_status." >&2
+  exit 1
+fi
+
+if [[ "$cleanup_output" != *"Sent KILL to verified job-owned processes"* ]]; then
+  echo "TERM-resistant owned process did not reach verified KILL." >&2
+  exit 1
+fi
+
+if [[ "$cleanup_output" != *"Sent KILL to verified job-owned processes:"*"$orphan_chrome_record"* ]]; then
+  echo "The real stopped Chromium record did not reach verified KILL." >&2
+  exit 1
+fi
+
+wait "$live_daemon_pid" 2>/dev/null || true
+
+if kill -0 "$live_daemon_pid" 2>/dev/null; then
+  echo "Live job-owned daemon remains after cleanup." >&2
+  exit 1
+fi
+
+if process_is_running "$orphan_chrome_pid"; then
+  echo "Reparented job-owned Chrome remains after cleanup." >&2
+  exit 1
+fi
+
+if ! kill -0 "$cleanup_shell_parent_pid" 2>/dev/null; then
+  echo "Cleanup terminated its calling shell." >&2
+  exit 1
+fi
+
+if ! kill -0 "$control_pid" 2>/dev/null; then
+  echo "Official AgentBrowser stale PID handling terminated an unrelated process." >&2
+  exit 1
+fi
+
+if ! kill -0 "$prefix_control_pid" 2>/dev/null; then
+  echo "Root-prefix matching terminated an unrelated process." >&2
+  exit 1
+fi
+
+if ! kill -0 "$fake_chrome_pid" 2>/dev/null; then
+  echo "A filename-only fake Chrome process was terminated." >&2
+  exit 1
+fi
+
+if [[ -e "$job_root" || -L "$job_root" ]]; then
+  echo "Runtime artifacts remain after cleanup." >&2
+  exit 1
+fi
+
+if [[ "$cleanup_elapsed_ms" -gt 12000 ]]; then
+  echo "Forced KILL cleanup exceeded its measured bound: ${cleanup_elapsed_ms}ms" >&2
+  exit 1
+fi
+
+echo "Forced cleanup harness passed in ${cleanup_elapsed_ms}ms."
+echo "Official 0.35.1 stale PID, root-prefix, fake Chrome, cleanup shell, and control processes survived."
+echo "Wrong PID:start_time was rejected; the correct record was handled."
+echo "Trusted real reparented Chromium reached KILL; sidecars, profile, and runtime root were removed."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,3 +23,141 @@ jobs:
     with:
       docs_command: mix docs -f html
       test_command: mix coveralls
+
+  agent-browser-smoke:
+    name: AgentBrowser smoke
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    env:
+      MIX_ENV: test
+      JIDO_BROWSER_REQUIRE_AGENT_BROWSER: "true"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Prepare AgentBrowser runtime root
+        shell: bash
+        run: |
+          set -euo pipefail
+          job_root="$(mktemp -d "$RUNNER_TEMP/jido-ab.XXXXXX")"
+          mkdir -p "$job_root/socket" "$job_root/tmp" "$job_root/xdg-runtime"
+          chmod 700 "$job_root/xdg-runtime"
+          printf '%s\n' "$job_root" > "$job_root/.jido-browser-agent-browser-root"
+
+          {
+            echo "AGENT_BROWSER_JOB_ROOT=$job_root"
+            echo "AGENT_BROWSER_SOCKET_DIR=$job_root/socket"
+            echo "TMPDIR=$job_root/tmp"
+            echo "TMP=$job_root/tmp"
+            echo "TEMP=$job_root/tmp"
+            echo "XDG_RUNTIME_DIR=$job_root/xdg-runtime"
+          } >> "$GITHUB_ENV"
+
+      - name: Setup Beam
+        uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1.24.0
+        with:
+          otp-version: "27"
+          elixir-version: "1.18"
+
+      - name: Install dependencies
+        shell: bash
+        run: |
+          set -euo pipefail
+          mix local.hex --force
+          mix local.rebar --force
+          mix deps.get
+          mix compile --warnings-as-errors
+
+      - name: Install supported AgentBrowser
+        id: agent_browser
+        shell: bash
+        run: |
+          set -euo pipefail
+          mix jido_browser.install agent_browser --if-missing
+
+          binary_path="$(mix run --no-start -e 'IO.write(Jido.Browser.Installer.bin_path(:agent_browser) || "")')"
+          supported_version="$(mix run --no-start -e 'IO.write(Jido.Browser.AgentBrowser.Runtime.supported_version())')"
+
+          test -x "$binary_path"
+          detected_version="$("$binary_path" --version)"
+          test "$detected_version" = "agent-browser $supported_version"
+          echo "binary_path=$binary_path" >> "$GITHUB_OUTPUT"
+
+          chromium_launcher=""
+
+          for command_name in google-chrome-stable google-chrome chromium chromium-browser; do
+            candidate="$(command -v "$command_name" 2>/dev/null || true)"
+
+            if [[ -n "$candidate" && -x "$candidate" ]]; then
+              chromium_launcher="$(readlink -f -- "$candidate")"
+              break
+            fi
+          done
+
+          test -x "$chromium_launcher"
+          chromium_version="$("$chromium_launcher" --version)"
+
+          case "$chromium_version" in
+            *Chrome*|*Chromium*) ;;
+            *)
+              echo "The installed browser is not Chromium: $chromium_version" >&2
+              exit 1
+              ;;
+          esac
+
+          trusted_chromium_executables=()
+
+          add_trusted_chromium_executable() {
+            local executable_path="$1"
+            local canonical_path
+            local existing_path
+
+            [[ -x "$executable_path" ]] || return 0
+            canonical_path="$(readlink -f -- "$executable_path")"
+
+            for existing_path in "${trusted_chromium_executables[@]}"; do
+              [[ "$existing_path" == "$canonical_path" ]] && return 0
+            done
+
+            trusted_chromium_executables+=("$canonical_path")
+          }
+
+          add_trusted_chromium_executable "$chromium_launcher"
+          chromium_install_dir="$(dirname -- "$chromium_launcher")"
+
+          for sibling_name in chrome chrome_crashpad_handler chromium headless_shell; do
+            add_trusted_chromium_executable "$chromium_install_dir/$sibling_name"
+          done
+
+          trusted_chromium_list="$(IFS=:; echo "${trusted_chromium_executables[*]}")"
+
+          {
+            echo "AGENT_BROWSER_EXECUTABLE_PATH=$chromium_launcher"
+            echo "AGENT_BROWSER_CHROMIUM_BINARY=$chromium_launcher"
+            echo "AGENT_BROWSER_CHROMIUM_EXECUTABLES=$trusted_chromium_list"
+          } >> "$GITHUB_ENV"
+
+      - name: Prove forced AgentBrowser cleanup
+        shell: bash
+        env:
+          AGENT_BROWSER_BINARY: ${{ steps.agent_browser.outputs.binary_path }}
+        run: |
+          set -euo pipefail
+          bash .github/scripts/test-agent-browser-cleanup.sh
+
+      - name: Run required AgentBrowser smoke suite
+        shell: bash
+        run: |
+          set -euo pipefail
+          mix test test/jido_browser/adapters/agent_browser_smoke_test.exs \
+            --include integration \
+            --only agent_browser_smoke \
+            --trace
+
+      - name: Clean up AgentBrowser processes
+        if: ${{ always() }}
+        shell: bash
+        env:
+          AGENT_BROWSER_BINARY: ${{ steps.agent_browser.outputs.binary_path }}
+        run: |
+          bash .github/scripts/cleanup-agent-browser.sh

--- a/test/jido_browser/adapters/agent_browser_integration_test.exs
+++ b/test/jido_browser/adapters/agent_browser_integration_test.exs
@@ -163,7 +163,8 @@ defmodule Jido.Browser.Adapters.AgentBrowserIntegrationTest do
       {:ok, session, _nav_result} =
         Browser.navigate(session, "#{base_url}/console-and-errors", timeout: @command_timeout)
 
-      Process.sleep(750)
+      {:ok, session, _wait_result} =
+        Browser.wait_for_selector(session, "#diagnostics-ready", state: :visible, timeout: 5_000)
 
       {:ok, _session, result} = Browser.console(session, timeout: @command_timeout)
       assert serialized(result) =~ "fixture-console-ready"
@@ -173,7 +174,8 @@ defmodule Jido.Browser.Adapters.AgentBrowserIntegrationTest do
       {:ok, session, _nav_result} =
         Browser.navigate(session, "#{base_url}/console-and-errors", timeout: @command_timeout)
 
-      Process.sleep(750)
+      {:ok, session, _wait_result} =
+        Browser.wait_for_selector(session, "#diagnostics-ready", state: :visible, timeout: 5_000)
 
       {:ok, _session, result} = Browser.errors(session, timeout: @command_timeout)
       serialized = serialized(result)

--- a/test/jido_browser/adapters/agent_browser_smoke_test.exs
+++ b/test/jido_browser/adapters/agent_browser_smoke_test.exs
@@ -1,0 +1,140 @@
+defmodule Jido.Browser.Adapters.AgentBrowserSmokeTest do
+  @moduledoc """
+  Required AgentBrowser smoke coverage against a local fixture server.
+
+  Run with:
+
+      JIDO_BROWSER_REQUIRE_AGENT_BROWSER=true \
+        mix test test/jido_browser/adapters/agent_browser_smoke_test.exs \
+        --include integration --only agent_browser_smoke
+  """
+
+  use ExUnit.Case, async: false
+
+  alias Jido.Browser
+  alias Jido.Browser.Adapters.AgentBrowser
+  alias Jido.Browser.AgentBrowser.Runtime
+  alias Jido.Browser.TestSupport.IntegrationTestServer
+
+  @availability (case Runtime.find_binary() do
+                   {:ok, binary} -> Runtime.ensure_supported_version(binary)
+                   {:error, reason} -> {:error, reason}
+                 end)
+
+  @moduletag :integration
+  @moduletag :agent_browser
+  @moduletag :agent_browser_smoke
+  @moduletag timeout: 180_000
+
+  if @availability != :ok do
+    if System.get_env("JIDO_BROWSER_REQUIRE_AGENT_BROWSER") == "true" do
+      raise "Required AgentBrowser smoke suite is unavailable: #{inspect(@availability)}"
+    else
+      @moduletag skip: "agent-browser smoke unavailable: #{inspect(@availability)}"
+    end
+  end
+
+  @command_timeout 60_000
+
+  setup_all do
+    {:ok, server} = IntegrationTestServer.start()
+    on_exit(fn -> IntegrationTestServer.stop(server) end)
+    {:ok, base_url: IntegrationTestServer.base_url(server)}
+  end
+
+  test "starts, navigates, snapshots, types, clicks, reads, and closes", %{base_url: base_url} do
+    assert {:ok, session} =
+             Browser.start_session(
+               adapter: AgentBrowser,
+               headless: true,
+               allowed_domains: ["127.0.0.1"],
+               timeout: @command_timeout
+             )
+
+    on_exit(fn -> assert :ok = end_session_if_running(session) end)
+
+    assert {:ok, session, _navigate_result} =
+             Browser.navigate(session, "#{base_url}/refs", timeout: @command_timeout)
+
+    assert {:ok, session, snapshot_result} = Browser.snapshot(session, timeout: @command_timeout)
+    refs = fetch_value(snapshot_result, :refs)
+
+    assert is_binary(fetch_value(snapshot_result, :snapshot))
+    assert is_map(refs)
+    assert map_size(refs) > 0
+
+    input_ref = ref_from_refs!(refs, "Ref Input Marker")
+    button_ref = ref_from_refs!(refs, "Use Ref Button Marker")
+
+    assert {:ok, session, _type_result} =
+             Browser.type(session, input_ref, "supported smoke", clear: true, timeout: @command_timeout)
+
+    assert {:ok, session, _click_result} =
+             Browser.click(session, button_ref, timeout: @command_timeout)
+
+    assert {:ok, session, read_result} =
+             Browser.get_text(session, "#ref-output", timeout: @command_timeout)
+
+    assert fetch_value(read_result, :text) == "Submitted: supported smoke"
+    assert :ok = Browser.end_session(session)
+    assert_eventually(fn -> session_stopped?(session) end)
+  end
+
+  defp end_session_if_running(session) do
+    case Runtime.lookup_session_server(session.id) do
+      {:ok, _pid} -> Browser.end_session(session)
+      :error -> :ok
+    end
+  catch
+    :exit, {:noproc, _call} -> :ok
+  end
+
+  defp session_stopped?(session) do
+    Runtime.lookup_session_server(session.id) == :error and
+      not File.exists?(Runtime.pid_path(session.id)) and
+      not File.exists?(Runtime.socket_path(session.id))
+  end
+
+  defp assert_eventually(condition, timeout \\ 5_000) do
+    deadline = System.monotonic_time(:millisecond) + timeout
+    do_assert_eventually(condition, deadline)
+  end
+
+  defp do_assert_eventually(condition, deadline) do
+    if condition.() do
+      :ok
+    else
+      if System.monotonic_time(:millisecond) >= deadline do
+        flunk("AgentBrowser session did not close before the timeout")
+      else
+        Process.sleep(20)
+        do_assert_eventually(condition, deadline)
+      end
+    end
+  end
+
+  defp ref_from_refs!(refs, marker) do
+    refs
+    |> Enum.find_value(fn {ref, entry} ->
+      name = fetch_value(entry, :name)
+
+      if is_binary(name) and String.contains?(String.downcase(name), String.downcase(marker)) do
+        normalize_ref(ref)
+      end
+    end)
+    |> case do
+      nil -> flunk("Could not find ref for #{inspect(marker)} in refs:\n#{inspect(refs, pretty: true)}")
+      ref -> ref
+    end
+  end
+
+  defp normalize_ref("@" <> _ = ref), do: ref
+  defp normalize_ref(ref), do: "@#{ref}"
+
+  defp fetch_value(map, key) do
+    case Map.fetch(map, key) do
+      {:ok, value} -> value
+      :error -> Map.get(map, Atom.to_string(key))
+    end
+  end
+end

--- a/test/support/integration_test_server.ex
+++ b/test/support/integration_test_server.ex
@@ -288,6 +288,7 @@ defmodule Jido.Browser.TestSupport.IntegrationTestServer do
        <body>
          <h1>Console And Errors Fixture</h1>
          <p>Used to validate browser diagnostics collection.</p>
+         <p id="diagnostics-ready" hidden>Diagnostics ready</p>
          <script>
            window.addEventListener("load", function () {
              console.log("fixture-console-ready");
@@ -300,6 +301,10 @@ defmodule Jido.Browser.TestSupport.IntegrationTestServer do
              window.setTimeout(function () {
                throw new Error("fixture-page-error");
              }, 100);
+
+             window.setTimeout(function () {
+               document.getElementById("diagnostics-ready").hidden = false;
+             }, 150);
            });
          </script>
        </body>


### PR DESCRIPTION
## Summary

- add a dedicated required Linux job that installs and verifies the centrally supported AgentBrowser version, currently `0.35.1`
- run a loopback-only fixture smoke test for start, navigate, snapshot, type, click, read, and explicit normal session close
- make the smoke suite fail when the required binary is missing or incompatible after installation
- replace the two fixed 750 ms diagnostic waits with fixture state waits
- put the socket directory, OS temp directories, Chromium profiles, and runtime metadata under one unique `$RUNNER_TEMP` root
- never pass unvalidated PID files to AgentBrowser cleanup commands; fallback cleanup does not invoke AgentBrowser close and does not read PID files
- require the exact NUL-delimited `AGENT_BROWSER_JOB_ROOT=$job_root` environment token for every cleanup target
- require the exact configured AgentBrowser binary device/inode for a daemon target
- resolve the validated installed Chromium launcher and controlled sibling executables to trusted canonical paths, then require an exact trusted device/inode plus an exact root-contained `--user-data-dir` argument for Chromium
- never trust a Chromium basename or a command-line root argument without the exact ownership environment token
- revalidate executable identity, environment ownership, profile boundary, PID, and start time immediately before every TERM or KILL signal
- use bounded TERM and KILL waits, remove the complete job root, and fail if a verified owned process or runtime artifact remains
- prove cleanup with the real official AgentBrowser 0.35.1 daemon and a real Chromium executable, plus deterministic stale-PID, filename-only, root-prefix, reparenting, identity, and hard-bound cases

## History

Issue #7 reported the integration gap and was closed as a duplicate. PR #8 added the broad integration coverage. This PR closes the remaining required default-adapter CI gap.

## Checks

- [PR CI run 33090518365](https://github.com/agentjido/jido_browser/actions/runs/33090518365) — passed, including the required `AgentBrowser smoke` job and all shared test and quality jobs
- final GitHub Linux cleanup harness — passed in 4093 ms with official AgentBrowser 0.35.1 and real Google Chrome
- verified TERM targets — `2650:32198` and `2689:32203`, where each value is `PID:start_time`
- verified KILL target — stopped, reparented real Chromium process `2689:32203`
- unrelated process referenced by `stale.pid` — survived
- unrelated `${job_root}-other/...` process — survived
- copied unrelated executable named `chrome` with a root-contained argument and no ownership environment — survived
- cleanup shell and unrelated control process — survived
- wrong `PID:start_time` record — rejected without a signal; correct record was handled
- stale and missing PID state, all sidecars, Chrome profile, and full runtime root — removed
- clean Ubuntu 24.04 x86-64 harness with official binary and Chrome for Testing — passed in 3999 ms
- real AgentBrowser `0.35.1` smoke suite in the isolated runtime root — 1 test, 0 failures
- AgentBrowser binary/runtime focused tests — 26 passed
- required mode with no AgentBrowser binary — failed as required with status 1
- required mode with AgentBrowser `0.24.0` — failed as required with status 1 and reported supported `0.35.1`
- `mix test` — 297 passed, 26 integration tests excluded
- `mix q` — compile, format, Credo, Dialyzer, and Doctor passed
- `actionlint` 1.7.7, `bash -n`, and ShellCheck — passed

## Commit-tree verification

- blocked `4d33e85` tree — `5a91d7334af0e3a047eaccb3de1f911cfcab5f9f`
- final `8a854af` tree — `86e2b35e1098a661a04e5c4afdcaefc75afc6778`
- direct `git diff 4d33e85..8a854af` — 3 changed files, 363 additions, 84 deletions: cleanup script, cleanup harness, and CI workflow

No changelog entry is included because this is hidden CI work.

Closes #65