### PR TITLE
deprecate(adapters): publish support tiers and warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ remains available without warm-pool support. `Lightpanda` is available as an
 optional limited adapter for lightweight DOM and JavaScript automation, with
 warm-pool support for prestarted CDP sessions.
 
+The [browser adapter support policy](guides/browser_adapter_support.md) is the
+canonical source for support levels, tested versions, CI coverage, and 3.0
+removal notices. It also covers the BrowseyHttp web-fetch runtime.
+
 The Hex package and OTP app remain `jido_browser`, while the public Elixir namespace is `Jido.Browser.*`.
 
 ## Installation
@@ -374,15 +378,15 @@ Configured `req`, `browsey`, and `extractous` options are merged with any per-ca
 - disables Lightpanda telemetry by default with `LIGHTPANDA_DISABLE_TELEMETRY=true`
 - does not provide AgentBrowser-native refs, state persistence, tab management, or console capture
 
-### Vibium (Legacy)
+### Vibium
 
-- retained for transitional compatibility
-- feature-frozen in 2.0
+- CLI-backed browser sessions without warm-pool support
+- navigation, click, type, PNG screenshots, content extraction, and JavaScript evaluation
 
-### Web (Legacy)
+### Web
 
-- retained for transitional compatibility
-- feature-frozen in 2.0
+- Firefox-backed browser sessions through the `web` CLI
+- optional warm session pools with persistent profiles
 
 ## Public API
 

--- a/guides/agent_browser_compatibility.md
+++ b/guides/agent_browser_compatibility.md
@@ -2,6 +2,9 @@
 
 Research date: 2026-08-27.
 
+For the current maintenance promise and CI level, see the canonical
+[browser adapter support policy](browser_adapter_support.md).
+
 ## Decision
 
 Use AgentBrowser 0.35.1 as the preferred supported version for Jido Browser 2.x.

--- a/guides/browser_adapter_support.md
+++ b/guides/browser_adapter_support.md
@@ -1,0 +1,66 @@
+# Browser Adapter Support
+
+Policy date: 2026-08-27.
+
+This guide is the canonical support policy for Jido Browser 2.x browser
+adapters and the BrowseyHttp web-fetch runtime. AgentBrowser is the supported
+default.
+
+## Support matrix
+
+| Adapter or runtime | Tested upstream version | CI level | Maintenance promise | Support conditions |
+| --- | --- | --- | --- | --- |
+| AgentBrowser | [0.35.1](https://github.com/vercel-labs/agent-browser/releases/tag/v0.35.1) | Required unit, quality, and Linux real-runtime smoke tests on each PR | Supported default for 2.x. Version or daemon protocol failures block a release. The project maintains the current public API and fixes compatibility and security defects. | Use AgentBrowser 0.35.1 and the supervised local daemon transport. The runtime rejects other AgentBrowser versions. The required smoke lane covers start, navigate, snapshot, click, type, read, and close. |
+| Lightpanda | [0.3.0](https://github.com/lightpanda-io/browser/releases/tag/0.3.0) | Required fake-runtime unit tests; opt-in real-runtime integration test | Limited support for the listed base operations and warm pools. The project fixes defects in those operations, but does not promise AgentBrowser feature parity. | Add `light_cdp ~> 0.2.1` and `lightpanda_ex ~> 0.1.0`. Use the 0.3.0 binary baseline. Support includes session lifecycle, navigation, click, type, PNG screenshots, content extraction, JavaScript evaluation, and warm pools. AgentBrowser refs, state persistence, tab management, and console capture are not supported. |
+| Vibium | [26.3.11](https://github.com/VibiumDev/vibium/releases/tag/v26.3.11) | Required installer and facade tests; opt-in real-runtime integration test | Compatibility support in 2.x. The adapter is feature-frozen. The project fixes critical compatibility and security defects in its current operations. | Use Vibium 26.3.11. Support is for unpooled sessions and the current navigation, click, type, PNG screenshot, content extraction, and JavaScript evaluation operations. Markdown extraction uses Vibium plain text. Newer Vibium releases are not part of this support promise. |
+| Web | No version tag. The installer uses upstream `main`, at [ef008308](https://github.com/chrismccord/web/commit/ef008308062d2f161155fd3396f54e1481352f54) on the policy date. | Required fake-runtime unit tests; opt-in real-runtime integration test | Deprecated. Only critical compatibility and security fixes are accepted in 2.x. The Web adapter will be removed in 3.0. | Use only for migration of existing browser sessions and warm pools. The installer does not pin an immutable upstream release. Move to AgentBrowser before 3.0. |
+| BrowseyHttp | Vendored upstream commit [0324a26d](https://github.com/s3cur3/browsey_http/commit/0324a26d3853aee39db54ad947a2f50769afda01), with documented local patches | Required vendored-runtime unit tests; opt-in external-network smoke test | Deprecated. Only critical compatibility and security fixes are accepted in 2.x. BrowseyHttp and its curl-impersonate assets will be removed in 3.0. | Use only for migration of existing `:browsey` web-fetch calls. It does not execute JavaScript. Move HTTP retrieval to the default Req backend. Use AgentBrowser when a page needs a rendered browser. |
+
+"Required" means that the check runs in the normal pull-request CI. "Opt-in"
+means that the test has the `:integration` tag and the normal test command
+excludes it. An opt-in test does not make an upstream runtime part of the
+required CI promise.
+
+## Evidence
+
+The AgentBrowser decision comes from
+[issue #74](https://github.com/agentjido/jido_browser/issues/74) and the
+[version and transport research](agent_browser_compatibility.md). That research
+tested the published 0.35.1 runtime with local fixtures. The required
+[AgentBrowser smoke workflow](https://github.com/agentjido/jido_browser/blob/main/.github/workflows/ci.yml)
+was added by [issue #65](https://github.com/agentjido/jido_browser/issues/65)
+and [PR #107](https://github.com/agentjido/jido_browser/pull/107).
+
+The other CI levels come from the current test configuration and adapter tests:
+
+- [`test/test_helper.exs`](https://github.com/agentjido/jido_browser/blob/main/test/test_helper.exs)
+  excludes all integration tests from the normal test command.
+- The Lightpanda
+  [unit](https://github.com/agentjido/jido_browser/blob/main/test/jido_browser/adapters/lightpanda_test.exs)
+  and
+  [integration](https://github.com/agentjido/jido_browser/blob/main/test/jido_browser/adapters/lightpanda_integration_test.exs)
+  tests define its verified operations. The adapter module defines its optional
+  dependency and feature conditions.
+- The Vibium installer pins 26.3.11. Its local-fixture integration test covers
+  the operations in the matrix.
+- The Web unit tests use a controlled fake binary. Its local-fixture integration
+  test is opt-in. The installer uses the unversioned upstream `main` branch.
+- The BrowseyHttp source records the exact upstream commit and local changes in
+  its
+  [vendor record](https://github.com/agentjido/jido_browser/blob/main/vendor/browsey_http/README.md).
+  Unit tests cover backend routing, result normalization, option validation,
+  and vendored runtime validation. The real network smoke test is opt-in.
+
+## Migration
+
+For the Web adapter, select `Jido.Browser.Adapters.AgentBrowser` and install the
+supported AgentBrowser runtime. AgentBrowser is the normal replacement because
+both adapters provide stateful browser sessions.
+
+For BrowseyHttp, select `:req` or
+`Jido.Browser.WebFetch.Backends.Req` for stateless HTTP retrieval. Select
+AgentBrowser only when the page needs JavaScript or browser rendering.
+
+The 3.0 removal work is tracked in
+[#80](https://github.com/agentjido/jido_browser/issues/80) for Web and
+[#81](https://github.com/agentjido/jido_browser/issues/81) for BrowseyHttp.

--- a/lib/jido_browser.ex
+++ b/lib/jido_browser.ex
@@ -6,6 +6,7 @@ defmodule Jido.Browser do
   In 2.0, the default adapter is `Jido.Browser.Adapters.AgentBrowser`.
   """
 
+  alias Jido.Browser.Deprecations
   alias Jido.Browser.Error
   alias Jido.Browser.FetchRich
   alias Jido.Browser.PoolAdapter
@@ -30,6 +31,7 @@ defmodule Jido.Browser do
   @spec start_pool(keyword()) :: {:ok, pid()} | {:error, term()}
   def start_pool(opts) do
     adapter = opts[:adapter] || configured_adapter()
+    :ok = Deprecations.warn(adapter)
 
     if PoolAdapter.supports_pools?(adapter) do
       adapter.start_pool(opts)
@@ -54,6 +56,7 @@ defmodule Jido.Browser do
   @spec start_session(keyword()) :: {:ok, Session.t()} | {:error, term()}
   def start_session(opts \\ []) do
     with {:ok, adapter} <- resolve_session_adapter(opts),
+         :ok <- Deprecations.warn(adapter),
          :ok <- validate_pool_capability(adapter, opts) do
       case adapter.start_session(opts) do
         {:ok, %Session{} = session} ->

--- a/lib/jido_browser/adapters/web.ex
+++ b/lib/jido_browser/adapters/web.ex
@@ -19,6 +19,7 @@ defmodule Jido.Browser.Adapters.Web do
   alias Jido.Browser.Adapters.Web.CLI
   alias Jido.Browser.Adapters.Web.PoolRuntime
   alias Jido.Browser.Application, as: BrowserApplication
+  alias Jido.Browser.Deprecations
   alias Jido.Browser.Error
   alias Jido.Browser.Session
   alias Jido.Browser.WarmPool.Lease
@@ -32,6 +33,8 @@ defmodule Jido.Browser.Adapters.Web do
   @impl true
   @spec start_pool(keyword()) :: {:ok, pid()} | {:error, term()}
   def start_pool(opts) do
+    :ok = Deprecations.warn(__MODULE__)
+
     with {:ok, manager_opts, startup_timeout} <- build_pool_start_opts(opts) do
       case TreeSupervisor.start_pool(manager_opts) do
         {:ok, pid} ->
@@ -50,6 +53,7 @@ defmodule Jido.Browser.Adapters.Web do
   @spec start_supervised_pool(keyword()) :: GenServer.on_start()
   def start_supervised_pool(opts) do
     with :ok <- BrowserApplication.ensure_started(),
+         :ok <- Deprecations.warn(__MODULE__),
          {:ok, manager_opts, startup_timeout} <- build_pool_start_opts(opts) do
       case TreeSupervisor.start_link(manager_opts) do
         {:ok, pid} ->
@@ -70,6 +74,8 @@ defmodule Jido.Browser.Adapters.Web do
 
   @impl true
   def start_session(opts \\ []) do
+    :ok = Deprecations.warn(__MODULE__)
+
     if pool = opts[:pool] do
       start_pooled_session(pool, opts)
     else

--- a/lib/jido_browser/application.ex
+++ b/lib/jido_browser/application.ex
@@ -3,13 +3,16 @@ defmodule Jido.Browser.Application do
 
   use Application
 
+  alias Jido.Browser.Deprecations
+
   @required_processes [
     Jido.Browser.AgentBrowser.SessionTreeSupervisor,
     Jido.Browser.AgentBrowser.Registry,
     Jido.Browser.AgentBrowser.SessionSupervisor,
     Jido.Browser.WarmPool.RootSupervisor,
     Jido.Browser.WarmPool.Registry,
-    Jido.Browser.WarmPool.Supervisor
+    Jido.Browser.WarmPool.Supervisor,
+    Deprecations
   ]
 
   @boot_poll_interval 10
@@ -17,9 +20,12 @@ defmodule Jido.Browser.Application do
 
   @impl true
   def start(_type, _args) do
+    :ok = Deprecations.reset_boot_state()
+
     children = [
       Jido.Browser.AgentBrowser.SessionTreeSupervisor,
-      Jido.Browser.WarmPool.RootSupervisor
+      Jido.Browser.WarmPool.RootSupervisor,
+      Deprecations
     ]
 
     Supervisor.start_link(children,

--- a/lib/jido_browser/deprecations.ex
+++ b/lib/jido_browser/deprecations.ex
@@ -1,0 +1,105 @@
+defmodule Jido.Browser.Deprecations do
+  @moduledoc false
+
+  use GenServer
+
+  require Logger
+
+  @agent_browser Jido.Browser.Adapters.AgentBrowser
+  @browsey_backend Jido.Browser.WebFetch.Backends.Browsey
+  @state_key {__MODULE__, :boot_warning_state}
+  @web_adapter Jido.Browser.Adapters.Web
+
+  @web_warning "#{inspect(@web_adapter)} (the Web adapter runtime) is deprecated and will be removed in " <>
+                 "Jido Browser 3.0. Use #{inspect(@agent_browser)} instead."
+
+  @browsey_warning "BrowseyHttp (the :browsey web-fetch runtime) is deprecated and will be removed in " <>
+                     "Jido Browser 3.0. Use Jido.Browser.WebFetch.Backends.Req for HTTP retrieval, " <>
+                     "or #{inspect(@agent_browser)} for rendered pages."
+
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  @doc false
+  @spec warn(term()) :: :ok
+  def warn(selection) do
+    case Process.whereis(__MODULE__) do
+      pid when is_pid(pid) -> safe_warn(pid, selection)
+      nil -> :ok
+    end
+  end
+
+  @doc false
+  @spec reset_boot_state() :: :ok
+  def reset_boot_state do
+    :persistent_term.put(@state_key, MapSet.new())
+    :ok
+  end
+
+  @impl true
+  def init(_opts) do
+    warned =
+      [configured_adapter(), configured_web_fetch_backend()]
+      |> Enum.reduce(boot_warning_state(), &warn_once/2)
+
+    {:ok, warned}
+  end
+
+  @impl true
+  def handle_call({:warn, selection}, _from, warned) do
+    {:reply, :ok, warn_once(selection, warned)}
+  end
+
+  defp safe_warn(pid, selection) do
+    GenServer.call(pid, {:warn, selection})
+  catch
+    :exit, _reason -> :ok
+  end
+
+  defp warn_once(selection, warned) do
+    case deprecation(selection) do
+      {key, message} ->
+        if MapSet.member?(warned, key) do
+          warned
+        else
+          warned = MapSet.put(warned, key)
+          :persistent_term.put(@state_key, warned)
+          Logger.warning(message)
+          warned
+        end
+
+      nil ->
+        warned
+    end
+  end
+
+  defp deprecation(@web_adapter), do: {:web, @web_warning}
+  defp deprecation(:web), do: {:web, @web_warning}
+  defp deprecation(@browsey_backend), do: {:browsey, @browsey_warning}
+  defp deprecation(Jido.Browser.Vendor.BrowseyHttp), do: {:browsey, @browsey_warning}
+  defp deprecation(:browsey), do: {:browsey, @browsey_warning}
+  defp deprecation(_selection), do: nil
+
+  defp boot_warning_state do
+    :persistent_term.get(@state_key, MapSet.new())
+  end
+
+  defp configured_adapter do
+    Application.get_env(:jido_browser, :adapter, @agent_browser)
+  end
+
+  defp configured_web_fetch_backend do
+    case Application.get_env(:jido_browser, :web_fetch, []) do
+      config when is_list(config) ->
+        if Keyword.keyword?(config), do: Keyword.get(config, :backend)
+
+      config when is_map(config) ->
+        Map.get(config, :backend)
+
+      _config ->
+        nil
+    end
+  end
+end

--- a/lib/jido_browser/plugin.ex
+++ b/lib/jido_browser/plugin.ex
@@ -32,6 +32,8 @@ defmodule Jido.Browser.Plugin do
   * `Evaluate` - Execute JavaScript in the browser
   """
 
+  alias Jido.Browser.Deprecations
+
   @action_registry [
     # Session lifecycle
     {Jido.Browser.Actions.StartSession, "browser.start_session"},
@@ -105,11 +107,14 @@ defmodule Jido.Browser.Plugin do
 
   @impl Jido.Plugin
   def mount(_agent, config) do
+    adapter = Map.get(config, :adapter, Jido.Browser.Adapters.AgentBrowser)
+    :ok = Deprecations.warn(adapter)
+
     initial_state = %{
       session: nil,
       headless: Map.get(config, :headless, true),
       timeout: Map.get(config, :timeout, 30_000),
-      adapter: Map.get(config, :adapter, Jido.Browser.Adapters.AgentBrowser),
+      adapter: adapter,
       pool: Map.get(config, :pool),
       checkout_timeout: Map.get(config, :checkout_timeout, 5_000),
       viewport: Map.get(config, :viewport, %{width: 1280, height: 720}),

--- a/lib/jido_browser/pool.ex
+++ b/lib/jido_browser/pool.ex
@@ -15,6 +15,7 @@ defmodule Jido.Browser.Pool do
   `Jido.Browser.start_pool/1` for scripts, tests, or ad hoc startup.
   """
 
+  alias Jido.Browser.Deprecations
   alias Jido.Browser.Error
   alias Jido.Browser.PoolAdapter
 
@@ -66,6 +67,7 @@ defmodule Jido.Browser.Pool do
   def start_link(opts) do
     opts = Keyword.put_new(opts, :name, @default_name)
     adapter = Keyword.get(opts, :adapter, configured_adapter())
+    :ok = Deprecations.warn(adapter)
 
     if PoolAdapter.supports_pools?(adapter) do
       adapter.start_supervised_pool(opts)

--- a/lib/jido_browser/web_fetch.ex
+++ b/lib/jido_browser/web_fetch.ex
@@ -8,6 +8,7 @@ defmodule Jido.Browser.WebFetch do
   browser session would be unnecessary or too expensive.
   """
 
+  alias Jido.Browser.Deprecations
   alias Jido.Browser.Error
 
   import Bitwise, only: [bsl: 2, bsr: 2]
@@ -1583,10 +1584,15 @@ defmodule Jido.Browser.WebFetch do
   end
 
   defp normalize_backend(:req), do: normalize_backend(Jido.Browser.WebFetch.Backends.Req)
-  defp normalize_backend(:browsey), do: normalize_backend(Jido.Browser.WebFetch.Backends.Browsey)
+
+  defp normalize_backend(:browsey) do
+    :ok = Deprecations.warn(:browsey)
+    normalize_backend(Jido.Browser.WebFetch.Backends.Browsey)
+  end
 
   defp normalize_backend(backend) when is_atom(backend) and not is_nil(backend) do
     if Code.ensure_loaded?(backend) and function_exported?(backend, :fetch, 2) do
+      :ok = Deprecations.warn(backend)
       {:ok, backend}
     else
       {:error,

--- a/lib/jido_browser/web_fetch/backends/browsey.ex
+++ b/lib/jido_browser/web_fetch/backends/browsey.ex
@@ -9,6 +9,7 @@ defmodule Jido.Browser.WebFetch.Backends.Browsey do
 
   @behaviour Jido.Browser.WebFetch.Backend
 
+  alias Jido.Browser.Deprecations
   alias Jido.Browser.Error
   alias Jido.Browser.Vendor.BrowseyHttp
 
@@ -16,6 +17,8 @@ defmodule Jido.Browser.WebFetch.Backends.Browsey do
   @default_timeout 30_000
   @impl true
   def fetch(url, opts) do
+    :ok = Deprecations.warn(__MODULE__)
+
     browsey_opts =
       opts
       |> Keyword.get(:browsey, [])

--- a/mix.exs
+++ b/mix.exs
@@ -115,6 +115,8 @@ defmodule Jido.Browser.MixProject do
       end,
       extras: [
         "README.md": [title: "Overview"],
+        "guides/browser_adapter_support.md": [title: "Browser Adapter Support"],
+        "guides/agent_browser_compatibility.md": [title: "AgentBrowser Compatibility"],
         "CHANGELOG.md": [title: "Changelog"],
         LICENSE: [title: "License"]
       ],
@@ -192,7 +194,7 @@ defmodule Jido.Browser.MixProject do
   defp package do
     [
       name: "jido_browser",
-      files: ~w(lib priv/vendor vendor .formatter.exs mix.exs README.md LICENSE CHANGELOG.md),
+      files: ~w(lib priv/vendor vendor guides .formatter.exs mix.exs README.md LICENSE CHANGELOG.md),
       licenses: ["Apache-2.0", "MIT"],
       links: %{
         "GitHub" => @source_url,

--- a/test/jido_browser/deprecations_test.exs
+++ b/test/jido_browser/deprecations_test.exs
@@ -1,0 +1,239 @@
+defmodule Jido.Browser.DeprecationsTest do
+  use ExUnit.Case, async: false
+
+  import ExUnit.CaptureLog
+
+  alias Jido.Browser.Adapters.AgentBrowser
+  alias Jido.Browser.Adapters.Lightpanda
+  alias Jido.Browser.Adapters.Vibium
+  alias Jido.Browser.Adapters.Web
+  alias Jido.Browser.Deprecations
+  alias Jido.Browser.TestSupport.FakeWebBinary
+  alias Jido.Browser.Vendor.BrowseyHttp
+  alias Jido.Browser.WebFetch.Backends.Browsey
+  alias Jido.Browser.WebFetch.Backends.Req
+
+  defmodule TestBrowseyClient do
+    def get(url, _opts) do
+      {:ok,
+       %{
+         status: 200,
+         headers: %{"content-type" => ["text/html"]},
+         body: "<html><head><title>Browsey test</title></head><body>ok</body></html>",
+         final_uri: URI.parse(url)
+       }}
+    end
+  end
+
+  setup do
+    old_adapter = Application.get_env(:jido_browser, :adapter, :__missing__)
+    old_web_fetch = Application.get_env(:jido_browser, :web_fetch, :__missing__)
+
+    Application.put_env(:jido_browser, :adapter, AgentBrowser)
+    Application.delete_env(:jido_browser, :web_fetch)
+    capture_log(&restart_application!/0)
+
+    on_exit(fn ->
+      restore_env(:adapter, old_adapter)
+      restore_env(:web_fetch, old_web_fetch)
+      capture_log(&restart_application!/0)
+    end)
+
+    :ok
+  end
+
+  test "warns once for the Web adapter module and alias" do
+    log =
+      capture_log(fn ->
+        assert :ok = Deprecations.warn(Web)
+        assert :ok = Deprecations.warn(:web)
+        assert :ok = Deprecations.warn(Web)
+      end)
+
+    assert warning_count(log, "Web adapter runtime") == 1
+    assert log =~ inspect(Web)
+    assert log =~ "removed in Jido Browser 3.0"
+    assert log =~ inspect(AgentBrowser)
+  end
+
+  test "warns once for each BrowseyHttp backend name and alias" do
+    log =
+      capture_log(fn ->
+        assert :ok = Deprecations.warn(:browsey)
+        assert :ok = Deprecations.warn(Browsey)
+        assert :ok = Deprecations.warn(BrowseyHttp)
+      end)
+
+    assert warning_count(log, "BrowseyHttp") == 1
+    assert log =~ ":browsey web-fetch runtime"
+    assert log =~ "removed in Jido Browser 3.0"
+    assert log =~ inspect(Req)
+    assert log =~ inspect(AgentBrowser)
+  end
+
+  test "serializes concurrent deprecated selections into one warning" do
+    log =
+      capture_log(fn ->
+        1..100
+        |> Task.async_stream(
+          fn index ->
+            selection = if rem(index, 2) == 0, do: Web, else: :web
+            Deprecations.warn(selection)
+          end,
+          max_concurrency: 20,
+          ordered: false
+        )
+        |> Enum.each(fn result -> assert result == {:ok, :ok} end)
+      end)
+
+    assert warning_count(log, "Web adapter runtime") == 1
+  end
+
+  test "does not warn for supported adapters and the Req backend" do
+    log =
+      capture_log(fn ->
+        for selection <- [AgentBrowser, Lightpanda, Vibium, Req, :req] do
+          assert :ok = Deprecations.warn(selection)
+        end
+      end)
+
+    assert log == ""
+  end
+
+  test "warns for configured deprecated runtimes during application boot" do
+    :ok = Application.stop(:jido_browser)
+    Application.put_env(:jido_browser, :adapter, Web)
+    Application.put_env(:jido_browser, :web_fetch, backend: :browsey)
+
+    log = capture_log(&start_application!/0)
+
+    assert warning_count(log, "Web adapter runtime") == 1
+    assert warning_count(log, "BrowseyHttp") == 1
+
+    repeated_log =
+      capture_log(fn ->
+        assert :ok = Deprecations.warn(Web)
+        assert :ok = Deprecations.warn(:browsey)
+      end)
+
+    assert repeated_log == ""
+  end
+
+  test "worker restart preserves runtimes and warning state until a real application restart" do
+    agent_browser_supervisor = Process.whereis(Jido.Browser.AgentBrowser.SessionTreeSupervisor)
+    warm_pool_supervisor = Process.whereis(Jido.Browser.WarmPool.RootSupervisor)
+    deprecations = Process.whereis(Deprecations)
+
+    assert is_pid(agent_browser_supervisor)
+    assert is_pid(warm_pool_supervisor)
+    assert is_pid(deprecations)
+
+    Application.put_env(:jido_browser, :adapter, Web)
+    first_log = capture_log(fn -> assert :ok = Deprecations.warn(Web) end)
+
+    restart_log =
+      capture_log(fn ->
+        ref = Process.monitor(deprecations)
+        Process.exit(deprecations, :kill)
+        assert_receive {:DOWN, ^ref, :process, ^deprecations, :killed}, 1_000
+        assert is_pid(await_restarted_process(Deprecations, deprecations))
+      end)
+
+    restarted_deprecations = Process.whereis(Deprecations)
+    repeated_log = capture_log(fn -> assert :ok = Deprecations.warn(Web) end)
+
+    assert Process.whereis(Jido.Browser.AgentBrowser.SessionTreeSupervisor) == agent_browser_supervisor
+    assert Process.whereis(Jido.Browser.WarmPool.RootSupervisor) == warm_pool_supervisor
+    assert restarted_deprecations != deprecations
+    assert warning_count(restart_log, "Web adapter runtime") == 0
+    assert repeated_log == ""
+
+    application_restart_log = capture_log(&restart_application!/0)
+    after_application_restart_log = capture_log(fn -> assert :ok = Deprecations.warn(Web) end)
+
+    assert warning_count(first_log, "Web adapter runtime") == 1
+    assert warning_count(application_restart_log, "Web adapter runtime") == 1
+    assert after_application_restart_log == ""
+  end
+
+  test "keeps Web session behavior and warns once across repeated sessions" do
+    FakeWebBinary.with_binary(:normal, fn binary, _profile_root ->
+      log =
+        capture_log(fn ->
+          assert {:ok, first_session} =
+                   Jido.Browser.start_session(adapter: Web, binary: binary, profile: "deprecated-first")
+
+          assert {:ok, _session, first_result} =
+                   Jido.Browser.navigate(first_session, "https://example.com/first")
+
+          assert first_result == %{content: "ok:https://example.com/first", url: "https://example.com/first"}
+          assert :ok = Jido.Browser.end_session(first_session)
+
+          assert {:ok, second_session} =
+                   Jido.Browser.start_session(adapter: Web, binary: binary, profile: "deprecated-second")
+
+          assert :ok = Jido.Browser.end_session(second_session)
+        end)
+
+      assert warning_count(log, "Web adapter runtime") == 1
+    end)
+  end
+
+  test "keeps BrowseyHttp behavior and warns once for alias and module requests" do
+    log =
+      capture_log(fn ->
+        for backend <- [:browsey, Browsey] do
+          assert {:ok, result} =
+                   Jido.Browser.web_fetch(
+                     "https://example.com/#{inspect(backend)}",
+                     backend: backend,
+                     browsey: [client: TestBrowseyClient],
+                     cache: false,
+                     format: :text
+                   )
+
+          assert result.content == "Browsey test\nok"
+        end
+      end)
+
+    assert warning_count(log, "BrowseyHttp") == 1
+  end
+
+  defp warning_count(log, text) do
+    log
+    |> String.split("\n")
+    |> Enum.count(&String.contains?(&1, text))
+  end
+
+  defp await_restarted_process(name, old_pid, attempts \\ 100)
+
+  defp await_restarted_process(_name, _old_pid, 0), do: flunk("process did not restart")
+
+  defp await_restarted_process(name, old_pid, attempts) do
+    case Process.whereis(name) do
+      pid when is_pid(pid) and pid != old_pid ->
+        pid
+
+      _pid ->
+        Process.sleep(10)
+        await_restarted_process(name, old_pid, attempts - 1)
+    end
+  end
+
+  defp restart_application! do
+    case Application.stop(:jido_browser) do
+      :ok -> start_application!()
+      {:error, {:not_started, :jido_browser}} -> start_application!()
+    end
+  end
+
+  defp start_application! do
+    case Application.ensure_all_started(:jido_browser) do
+      {:ok, _applications} -> :ok
+      {:error, reason} -> raise "could not start jido_browser: #{inspect(reason)}"
+    end
+  end
+
+  defp restore_env(key, :__missing__), do: Application.delete_env(:jido_browser, key)
+  defp restore_env(key, value), do: Application.put_env(:jido_browser, key, value)
+end


### PR DESCRIPTION
## Summary

- publish one canonical support matrix for AgentBrowser, Lightpanda, Vibium, Web, and BrowseyHttp
- keep AgentBrowser 0.35.1 as the supported default and record required versus opt-in CI levels
- deprecate Web and BrowseyHttp for removal in 3.0, with AgentBrowser and Req migration paths
- emit one application-owned, concurrency-safe warning per deprecated runtime per Jido Browser application boot
- cover configured defaults, runtime module and atom aliases, direct sessions and requests, concurrent selections, supported adapters, worker restart, and real application restart
- preserve the destination and redirect security policy merged in #105

## Warning lifecycle

Jido.Browser.Deprecations is the last child of the Jido Browser rest-for-one supervisor. The application resets its boot-scoped state before it starts the child tree. The state contains only the fixed Web and BrowseyHttp keys. All request processes share it. A deprecation-worker restart reloads the same boot state and cannot restart the browser runtime children. A real application stop and start resets the state and permits one new warning for each deprecated runtime.

## Checks

- forced compile with warnings as errors for each commit
- format check for each commit
- documentation build for the policy commit
- focused deprecation, destination-policy, and redirect-policy tests: 47 passed
- full test suite: 344 passed, 26 integration tests excluded
- HTML coverage: 66.7%
- quality: compile, format, Credo, Dialyzer, and Doctor passed
- ExDoc HTML build passed
- Hex audit and unused dependency checks passed
- Hex package and docs dry run passed; both guides are included
- local AgentBrowser 0.35.1 required smoke: 1 passed

No manual CHANGELOG.md edit is included. The conventional PR title produces the single Deprecated entry for 2.3.0.

Closes #75