### PR TITLE
fix(browsey): handle fast process exits without a PID race

### DIFF
--- a/test/jido_browser/browsey_exec_test.exs
+++ b/test/jido_browser/browsey_exec_test.exs
@@ -3,62 +3,299 @@ defmodule Jido.Browser.BrowseyExecTest do
 
   alias Jido.Browser.Vendor.BrowseyHttp.Util.Exec
 
-  test "keeps stdout and stderr separate on normal success" do
-    shell = System.find_executable("sh") || "/bin/sh"
+  @fast_exit_iterations 500
+  @fixture_term_wait_ms 250
+  @fixture_kill_wait_ms 1_000
 
-    assert {:ok, result} =
-             Exec.exec(
-               shell,
-               ["-c", ~s(printf normal; printf diagnostic > "$2"), "browsey-exec-test"],
-               1_000
-             )
+  test "repeated fast successful exits return their existing result and preserve an unrelated process" do
+    with_trap_exit(fn ->
+      executable = System.find_executable("true") || "/usr/bin/true"
 
-    assert IO.iodata_to_binary(result[:stdout]) == "normal"
-    assert IO.iodata_to_binary(result[:stderr]) == "diagnostic"
-  end
+      with_unrelated_process(fn unrelated_port, unrelated_pid ->
+        for _iteration <- 1..@fast_exit_iterations do
+          assert {:ok, [stdout: [], stderr: [""]]} = Exec.exec(executable, [], 1_000)
+        end
 
-  test "terminates and reaps the exact port process on timeout" do
-    shell = System.find_executable("sh") || "/bin/sh"
-    pid_path = tmp_path("browsey_timeout_pid")
-    File.rm(pid_path)
-    on_exit(fn -> File.rm(pid_path) end)
-
-    task =
-      Task.async(fn ->
-        Exec.exec(
-          shell,
-          [
-            "-c",
-            ~s(trap '' TERM; printf "%s" "$$" > "$0"; printf timeout > "$2"; while :; do :; done),
-            pid_path
-          ],
-          100
-        )
+        assert os_process_alive?(unrelated_pid)
+        assert linked_ports() == [unrelated_port]
+        refute_port_messages()
       end)
-
-    port = wait_for_task_port(task.pid)
-    {:os_pid, os_pid} = Port.info(port, :os_pid)
-    assert wait_for_file(pid_path)
-    assert pid_path |> File.read!() |> String.to_integer() == os_pid
-
-    assert {:error, result} = Task.await(task, 2_000)
-    assert result[:exit_status] == 28
-    assert IO.iodata_to_binary(result[:stderr]) == "timeout"
-    assert Port.info(port) == nil
-    refute os_process_alive?(os_pid)
+    end)
   end
 
-  defp wait_for_task_port(task_pid), do: wait_until(fn -> task_port(task_pid) end, 1_000)
+  test "repeated fast non-zero exits return their existing result" do
+    with_trap_exit(fn ->
+      executable = System.find_executable("false") || "/usr/bin/false"
 
-  defp task_port(task_pid) do
-    case Process.info(task_pid, :links) do
-      {:links, links} -> Enum.find(links, &is_port/1)
-      nil -> nil
+      for _iteration <- 1..@fast_exit_iterations do
+        assert {:error, result} = Exec.exec(executable, [], 1_000)
+        assert result[:exit_status] == 1
+        assert result[:observed_bytes] == 0
+        assert result[:stdout] == []
+        assert result[:stderr] == [""]
+      end
+
+      assert linked_ports() == []
+      refute_port_messages()
+    end)
+  end
+
+  test "deterministically collects a successful process that exits before PID discovery" do
+    with_trap_exit(fn ->
+      with_unrelated_process(fn unrelated_port, unrelated_pid ->
+        unrelated_exit_pid = queue_unrelated_exit()
+        unrelated_exit_port = queue_unrelated_port_exit()
+        script = controlled_script(~s(printf forced-success; printf forced-diagnostic > "$3"))
+
+        {result, port, os_pid, stderr_path} = controlled_exec(script, nil)
+
+        assert {:ok, output} = result
+        assert IO.iodata_to_binary(output[:stdout]) == "forced-success"
+        assert IO.iodata_to_binary(output[:stderr]) == "forced-diagnostic"
+        refute File.exists?(stderr_path)
+        assert_exact_port_reaped(port, os_pid)
+
+        assert os_process_alive?(unrelated_pid)
+        assert linked_ports() == [unrelated_port]
+        assert_receive {:EXIT, ^unrelated_exit_pid, :unrelated_exit}, 0
+        assert_receive {:EXIT, ^unrelated_exit_port, :normal}, 0
+        refute_port_messages()
+      end)
+    end)
+  end
+
+  test "deterministically collects a non-zero process that exits before PID discovery" do
+    with_trap_exit(fn ->
+      script = controlled_script(~s(printf forced-failure; printf forced-error > "$3"; exit 17))
+
+      {result, port, os_pid, stderr_path} = controlled_exec(script, nil)
+
+      assert {:error, output} = result
+      assert output[:exit_status] == 17
+      assert output[:observed_bytes] == byte_size("forced-failure")
+      assert IO.iodata_to_binary(output[:stdout]) == "forced-failure"
+      assert IO.iodata_to_binary(output[:stderr]) == "forced-error"
+      refute File.exists?(stderr_path)
+      assert_exact_port_reaped(port, os_pid)
+      refute_port_messages()
+    end)
+  end
+
+  test "deterministically applies the response limit after a process exits before PID discovery" do
+    with_trap_exit(fn ->
+      with_unrelated_process(fn unrelated_port, unrelated_pid ->
+        script = controlled_script(~s(printf 123456; printf limit-error > "$3"))
+
+        {result, port, os_pid, stderr_path} = controlled_exec(script, nil, 4)
+
+        assert {:error, output} = result
+        assert output[:exit_status] == 63
+        assert output[:observed_bytes] == 6
+        assert output[:response_too_large?] == true
+        assert output[:stdout] == []
+        assert IO.iodata_to_binary(output[:stderr]) == "limit-error"
+        refute File.exists?(stderr_path)
+        assert_exact_port_reaped(port, os_pid)
+
+        assert os_process_alive?(unrelated_pid)
+        assert linked_ports() == [unrelated_port]
+        refute_port_messages()
+      end)
+    end)
+  end
+
+  test "normal fixture cleanup neutralizes its late fallback" do
+    with_trap_exit(fn ->
+      fixture = start_unrelated_process()
+      {port, _monitor_ref, os_pid, completion} = fixture
+
+      try do
+        assert os_process_alive?(os_pid)
+        assert linked_ports() == [port]
+      after
+        complete_unrelated_process_cleanup(fixture)
+      end
+
+      signal_ref = make_ref()
+      owner = self()
+
+      assert :already_complete =
+               fallback_cleanup_unrelated_process(port, os_pid, completion, fn pid, signal ->
+                 send(owner, {signal_ref, pid, signal})
+               end)
+
+      refute_receive {^signal_ref, ^os_pid, _signal}, 0
+      refute_port_messages()
+    end)
+  end
+
+  test "fallback does not signal an unrelated PID after the recorded port closes" do
+    with_trap_exit(fn ->
+      with_unrelated_process(fn _unrelated_port, unrelated_pid ->
+        closed_port = closed_test_port()
+        active_completion = new_fixture_completion()
+        signal_ref = make_ref()
+        owner = self()
+
+        assert {:not_owned, nil} =
+                 fallback_cleanup_unrelated_process(closed_port, unrelated_pid, active_completion, fn pid, signal ->
+                   send(owner, {signal_ref, pid, signal})
+                 end)
+
+        refute_receive {^signal_ref, ^unrelated_pid, _signal}, 0
+        assert os_process_alive?(unrelated_pid)
+        refute_port_messages()
+      end)
+    end)
+  end
+
+  test "reaps exact port EXIT signals after successful and non-zero exits" do
+    with_trap_exit(fn ->
+      success_script = controlled_script(~s(printf normal; printf diagnostic > "$3"))
+      {success, success_port, success_pid, success_stderr} = controlled_exec(success_script, :exact)
+
+      assert {:ok, success_output} = success
+      assert IO.iodata_to_binary(success_output[:stdout]) == "normal"
+      assert IO.iodata_to_binary(success_output[:stderr]) == "diagnostic"
+      refute File.exists?(success_stderr)
+      assert_exact_port_reaped(success_port, success_pid)
+
+      failure_script = controlled_script(~s(printf failed; printf failure > "$3"; exit 9))
+      {failure, failure_port, failure_pid, failure_stderr} = controlled_exec(failure_script, :exact)
+
+      assert {:error, failure_output} = failure
+      assert failure_output[:exit_status] == 9
+      assert IO.iodata_to_binary(failure_output[:stdout]) == "failed"
+      assert IO.iodata_to_binary(failure_output[:stderr]) == "failure"
+      refute File.exists?(failure_stderr)
+      assert_exact_port_reaped(failure_port, failure_pid)
+      refute_port_messages()
+    end)
+  end
+
+  test "terminates and reaps the exact port process and EXIT signal on timeout" do
+    with_trap_exit(fn ->
+      script = controlled_script(~s(trap '' TERM; printf timeout > "$3"; while :; do :; done))
+
+      {result, port, os_pid, stderr_path} = controlled_exec(script, :exact, :infinity, 100)
+
+      assert {:error, output} = result
+      assert output[:exit_status] == 28
+      assert IO.iodata_to_binary(output[:stderr]) == "timeout"
+      refute File.exists?(stderr_path)
+      assert_exact_port_reaped(port, os_pid)
+    end)
+  end
+
+  test "terminates and reaps the exact port process and EXIT signal at the response limit" do
+    with_trap_exit(fn ->
+      script =
+        controlled_script(~s(trap '' TERM; printf response-limit > "$3"; printf 123456; while :; do :; done))
+
+      {result, port, os_pid, stderr_path} = controlled_exec(script, :exact, 4)
+
+      assert {:error, output} = result
+      assert output[:exit_status] == 63
+      assert output[:observed_bytes] > 4
+      assert output[:response_too_large?] == true
+      assert output[:stdout] == []
+      assert IO.iodata_to_binary(output[:stderr]) == "response-limit"
+      refute File.exists?(stderr_path)
+      assert_exact_port_reaped(port, os_pid)
+    end)
+  end
+
+  defp controlled_script(body) do
+    ~s(while [ ! -f "$1" ]; do :; done; printf '%s' "$3" > "$0"; #{body})
+  end
+
+  defp controlled_exec(script, pid_result, max_output_bytes \\ :infinity, timeout \\ 1_000) do
+    shell = System.find_executable("sh") || "/bin/sh"
+    details_path = tmp_path("browsey_controlled_details")
+    gate_path = tmp_path("browsey_controlled_gate")
+    File.rm(details_path)
+    File.rm(gate_path)
+    on_exit(fn -> File.rm(details_path) end)
+    on_exit(fn -> File.rm(gate_path) end)
+
+    owner = self()
+    lookup_ref = make_ref()
+    pid_lookup = controlled_pid_lookup(owner, lookup_ref, gate_path, details_path, pid_result)
+
+    result = Exec.__test_exec__(shell, ["-c", script, details_path, gate_path], timeout, max_output_bytes, pid_lookup)
+    assert_receive {^lookup_ref, port, os_pid}, 0
+    stderr_path = File.read!(details_path)
+    File.rm(details_path)
+    File.rm(gate_path)
+
+    {result, port, os_pid, stderr_path}
+  end
+
+  defp controlled_pid_lookup(owner, lookup_ref, gate_path, details_path, pid_result) do
+    fn port ->
+      {:os_pid, os_pid} = Port.info(port, :os_pid)
+      send(owner, {lookup_ref, port, os_pid})
+      File.write!(gate_path, "run")
+      true = wait_until(fn -> existing_file?(details_path) end, 1_000)
+      controlled_pid_result(pid_result, port, os_pid)
     end
   end
 
-  defp wait_for_file(path) do
-    wait_until(fn -> if File.exists?(path), do: true end, 1_000)
+  defp controlled_pid_result(:exact, _port, os_pid), do: {:os_pid, os_pid}
+
+  defp controlled_pid_result(nil, port, _os_pid) do
+    true = wait_until(fn -> closed_port?(port) end, 1_000)
+    nil
+  end
+
+  defp closed_port?(port) do
+    if Port.info(port) == nil, do: true
+  end
+
+  defp existing_file?(path) do
+    if File.exists?(path), do: true
+  end
+
+  defp with_trap_exit(fun) do
+    previous = Process.flag(:trap_exit, true)
+
+    try do
+      result = fun.()
+      assert Process.info(self(), :trap_exit) == {:trap_exit, true}
+      result
+    after
+      Process.flag(:trap_exit, previous)
+    end
+  end
+
+  defp queue_unrelated_exit do
+    pid = spawn_link(fn -> exit(:unrelated_exit) end)
+
+    assert wait_until(
+             fn ->
+               {:messages, messages} = Process.info(self(), :messages)
+               if Enum.any?(messages, &match?({:EXIT, ^pid, :unrelated_exit}, &1)), do: true
+             end,
+             1_000
+           )
+
+    pid
+  end
+
+  defp queue_unrelated_port_exit do
+    executable = System.find_executable("true") || "/usr/bin/true"
+    port = Port.open({:spawn_executable, executable}, [:exit_status])
+    assert_receive {^port, {:exit_status, 0}}, 1_000
+
+    assert wait_until(
+             fn ->
+               {:messages, messages} = Process.info(self(), :messages)
+               if Enum.any?(messages, &match?({:EXIT, ^port, :normal}, &1)), do: true
+             end,
+             1_000
+           )
+
+    port
   end
 
   defp wait_until(fun, timeout) do
@@ -81,11 +318,262 @@ defmodule Jido.Browser.BrowseyExecTest do
     end
   end
 
+  defp assert_exact_port_reaped(port, os_pid) do
+    assert Port.info(port) == nil
+    refute os_process_alive?(os_pid)
+    refute port in linked_ports()
+
+    {:messages, messages} = Process.info(self(), :messages)
+    refute Enum.any?(messages, &exact_port_message?(&1, port))
+  end
+
+  defp exact_port_message?({port, {:data, _data}}, port), do: true
+  defp exact_port_message?({port, {:exit_status, _status}}, port), do: true
+  defp exact_port_message?({:EXIT, port, _reason}, port), do: true
+  defp exact_port_message?({:DOWN, _ref, :port, port, _reason}, port), do: true
+  defp exact_port_message?(_message, _port), do: false
+
   defp os_process_alive?(pid) do
-    case System.cmd(kill_path(), ["-0", Integer.to_string(pid)], stderr_to_stdout: true, env: %{}) do
-      {_output, 0} -> true
-      {_output, _status} -> false
+    case os_process_alive_result(pid) do
+      {:ok, alive?} -> alive?
+      :timeout -> flunk("OS process check did not return")
     end
+  end
+
+  defp os_process_alive_result(pid) do
+    owner = self()
+    result_ref = make_ref()
+
+    spawn(fn ->
+      result = System.cmd(kill_path(), ["-0", Integer.to_string(pid)], stderr_to_stdout: true, env: %{})
+      send(owner, {result_ref, result})
+    end)
+
+    receive do
+      {^result_ref, {_output, 0}} -> {:ok, true}
+      {^result_ref, {_output, _status}} -> {:ok, false}
+    after
+      1_000 -> :timeout
+    end
+  end
+
+  defp with_unrelated_process(fun) do
+    fixture = start_unrelated_process()
+    {port, _monitor_ref, os_pid, _completion} = fixture
+
+    try do
+      fun.(port, os_pid)
+    after
+      complete_unrelated_process_cleanup(fixture)
+    end
+  end
+
+  defp start_unrelated_process do
+    sleep = System.find_executable("sleep") || "/bin/sleep"
+    port = Port.open({:spawn_executable, sleep}, [:exit_status, args: ["60"]])
+    {:os_pid, os_pid} = Port.info(port, :os_pid)
+    monitor_ref = :erlang.monitor(:port, port)
+    completion = new_fixture_completion()
+
+    on_exit(fn ->
+      fallback_cleanup_unrelated_process(port, os_pid, completion)
+    end)
+
+    {port, monitor_ref, os_pid, completion}
+  end
+
+  defp complete_unrelated_process_cleanup({port, monitor_ref, os_pid, completion}) do
+    assert cleanup_unrelated_process(port, monitor_ref, os_pid)
+    assert_unrelated_process_reaped(port, monitor_ref, os_pid)
+    :atomics.put(completion, 1, 1)
+  end
+
+  defp cleanup_unrelated_process(port, monitor_ref, os_pid) do
+    process_dead? = terminate_unrelated_process(port, os_pid)
+    port_reaped? = await_fixture_port_down(port, monitor_ref, @fixture_kill_wait_ms) == :ok
+    process_dead? and port_reaped?
+  end
+
+  defp fallback_cleanup_unrelated_process(port, os_pid, completion) do
+    fallback_cleanup_unrelated_process(port, os_pid, completion, &signal_os_process/2)
+  end
+
+  defp fallback_cleanup_unrelated_process(port, os_pid, completion, signal_fun) do
+    if fixture_cleanup_complete?(completion) do
+      :already_complete
+    else
+      monitor_ref = :erlang.monitor(:port, port)
+
+      case Port.info(port, :os_pid) do
+        {:os_pid, ^os_pid} ->
+          process_dead? = terminate_unrelated_process(port, os_pid, signal_fun)
+          port_reaped? = await_fixture_port_down(port, monitor_ref, @fixture_kill_wait_ms) == :ok
+          {:active_cleanup, process_dead? and port_reaped?}
+
+        port_pid ->
+          :erlang.demonitor(monitor_ref, [:flush])
+          flush_exact_fixture_port_messages(port, monitor_ref)
+          {:not_owned, port_pid}
+      end
+    end
+  end
+
+  defp terminate_unrelated_process(port, os_pid) do
+    terminate_unrelated_process(port, os_pid, &signal_os_process/2)
+  end
+
+  defp terminate_unrelated_process(port, os_pid, signal_fun) do
+    case os_process_alive_result(os_pid) do
+      {:ok, false} -> true
+      _result -> terminate_live_unrelated_process(port, os_pid, signal_fun)
+    end
+  end
+
+  defp terminate_live_unrelated_process(port, os_pid, signal_fun) do
+    case signal_exact_fixture_process(port, os_pid, "TERM", signal_fun) do
+      {:signaled, _result} -> wait_for_term_or_kill(port, os_pid, signal_fun)
+      {:not_owned, _port_pid} -> false
+    end
+  end
+
+  defp wait_for_term_or_kill(port, os_pid, signal_fun) do
+    if wait_for_os_process_exit(os_pid, @fixture_term_wait_ms) do
+      true
+    else
+      case signal_exact_fixture_process(port, os_pid, "KILL", signal_fun) do
+        {:signaled, _result} -> wait_for_os_process_exit(os_pid, @fixture_kill_wait_ms)
+        {:not_owned, _port_pid} -> false
+      end
+    end
+  end
+
+  defp signal_exact_fixture_process(port, os_pid, signal, signal_fun) do
+    case Port.info(port, :os_pid) do
+      {:os_pid, ^os_pid} -> {:signaled, signal_fun.(os_pid, signal)}
+      port_pid -> {:not_owned, port_pid}
+    end
+  end
+
+  defp signal_os_process(os_pid, signal) do
+    owner = self()
+    result_ref = make_ref()
+
+    spawn(fn ->
+      result =
+        System.cmd(kill_path(), ["-#{signal}", Integer.to_string(os_pid)], stderr_to_stdout: true, env: %{})
+
+      send(owner, {result_ref, result})
+    end)
+
+    receive do
+      {^result_ref, result} -> result
+    after
+      1_000 -> :timeout
+    end
+  end
+
+  defp wait_for_os_process_exit(os_pid, timeout) do
+    wait_until(
+      fn ->
+        case os_process_alive_result(os_pid) do
+          {:ok, false} -> true
+          _result -> nil
+        end
+      end,
+      timeout
+    ) == true
+  end
+
+  defp closed_test_port do
+    executable = System.find_executable("true") || "/usr/bin/true"
+    port = Port.open({:spawn_executable, executable}, [:exit_status])
+    monitor_ref = :erlang.monitor(:port, port)
+    assert await_fixture_port_down(port, monitor_ref, @fixture_kill_wait_ms) == :ok
+    assert Port.info(port) == nil
+    port
+  end
+
+  defp new_fixture_completion do
+    :atomics.new(1, [])
+  end
+
+  defp fixture_cleanup_complete?(completion) do
+    :atomics.get(completion, 1) == 1
+  end
+
+  defp await_fixture_port_down(port, monitor_ref, timeout) do
+    deadline = System.monotonic_time(:millisecond) + timeout
+    await_fixture_port_down_until(port, monitor_ref, deadline)
+  end
+
+  defp await_fixture_port_down_until(port, monitor_ref, deadline) do
+    remaining = deadline - System.monotonic_time(:millisecond)
+
+    if remaining <= 0 do
+      :timeout
+    else
+      receive do
+        {^port, {:data, _data}} ->
+          await_fixture_port_down_until(port, monitor_ref, deadline)
+
+        {^port, {:exit_status, _status}} ->
+          await_fixture_port_down_until(port, monitor_ref, deadline)
+
+        {:EXIT, ^port, _reason} ->
+          await_fixture_port_down_until(port, monitor_ref, deadline)
+
+        {:DOWN, ^monitor_ref, :port, ^port, _reason} ->
+          flush_exact_fixture_port_messages(port, monitor_ref)
+          :ok
+      after
+        remaining -> :timeout
+      end
+    end
+  end
+
+  defp flush_exact_fixture_port_messages(port, monitor_ref) do
+    receive do
+      {^port, {:data, _data}} -> flush_exact_fixture_port_messages(port, monitor_ref)
+      {^port, {:exit_status, _status}} -> flush_exact_fixture_port_messages(port, monitor_ref)
+      {:EXIT, ^port, _reason} -> flush_exact_fixture_port_messages(port, monitor_ref)
+      {:DOWN, ^monitor_ref, :port, ^port, _reason} -> flush_exact_fixture_port_messages(port, monitor_ref)
+    after
+      0 -> :ok
+    end
+  end
+
+  defp assert_unrelated_process_reaped(port, monitor_ref, os_pid) do
+    refute os_process_alive?(os_pid)
+    assert Port.info(port) == nil
+    refute port in linked_ports()
+
+    {:messages, messages} = Process.info(self(), :messages)
+    refute Enum.any?(messages, &exact_fixture_port_message?(&1, port, monitor_ref))
+  end
+
+  defp exact_fixture_port_message?({port, {:data, _data}}, port, _monitor_ref), do: true
+  defp exact_fixture_port_message?({port, {:exit_status, _status}}, port, _monitor_ref), do: true
+  defp exact_fixture_port_message?({:EXIT, port, _reason}, port, _monitor_ref), do: true
+
+  defp exact_fixture_port_message?({:DOWN, monitor_ref, :port, port, _reason}, port, monitor_ref), do: true
+
+  defp exact_fixture_port_message?(_message, _port, _monitor_ref), do: false
+
+  defp refute_port_messages do
+    {:messages, messages} = Process.info(self(), :messages)
+
+    refute Enum.any?(messages, fn
+             {port, {:data, _data}} when is_port(port) -> true
+             {port, {:exit_status, _status}} when is_port(port) -> true
+             {:EXIT, port, _reason} when is_port(port) -> true
+             {:DOWN, _ref, :port, port, _reason} when is_port(port) -> true
+             _message -> false
+           end)
+  end
+
+  defp linked_ports do
+    {:links, links} = Process.info(self(), :links)
+    Enum.filter(links, &is_port/1)
   end
 
   defp kill_path, do: System.find_executable("kill") || "/bin/kill"

--- a/vendor/browsey_http/lib/browsey_http/util/exec.ex
+++ b/vendor/browsey_http/lib/browsey_http/util/exec.ex
@@ -11,11 +11,32 @@ defmodule Jido.Browser.Vendor.BrowseyHttp.Util.Exec do
           {:ok, [{:stdout | :stderr, [binary()]}]} | {:error, Keyword.t()}
   def exec(executable, args, timeout, max_output_bytes \\ :infinity)
       when is_binary(executable) and is_list(args) do
+    exec_with_pid_lookup(executable, args, timeout, max_output_bytes, &Port.info(&1, :os_pid))
+  end
+
+  if Mix.env() == :test do
+    @doc false
+    @spec __test_exec__(
+            Path.t(),
+            [String.t()],
+            timeout(),
+            max_output_bytes(),
+            (port() -> {:os_pid, non_neg_integer()} | nil)
+          ) :: {:ok, [{:stdout | :stderr, [binary()]}]} | {:error, Keyword.t()}
+    def __test_exec__(executable, args, timeout, max_output_bytes, pid_lookup)
+        when is_binary(executable) and is_list(args) and is_function(pid_lookup, 1) do
+      # This seam is compiled only in the project test build. It forces the post-open
+      # PID race without an application environment or process dictionary hook.
+      exec_with_pid_lookup(executable, args, timeout, max_output_bytes, pid_lookup)
+    end
+  end
+
+  defp exec_with_pid_lookup(executable, args, timeout, max_output_bytes, pid_lookup) do
     stderr_path = tmp_path("browsey_stderr")
 
     try do
       executable
-      |> run_executable(args, stderr_path, timeout, max_output_bytes)
+      |> run_executable(args, stderr_path, timeout, max_output_bytes, pid_lookup)
       |> format_result(stderr_path)
     after
       File.rm(stderr_path)
@@ -27,7 +48,7 @@ defmodule Jido.Browser.Vendor.BrowseyHttp.Util.Exec do
     System.cmd("id", ["-u"], env: %{}) == {"0\n", 0}
   end
 
-  defp run_executable(executable, args, stderr_path, timeout, max_output_bytes) do
+  defp run_executable(executable, args, stderr_path, timeout, max_output_bytes, pid_lookup) do
     port =
       Port.open({:spawn_executable, executable}, [
         :binary,
@@ -37,12 +58,58 @@ defmodule Jido.Browser.Vendor.BrowseyHttp.Util.Exec do
         env: [{~c"BROWSEY_STDERR_PATH", String.to_charlist(stderr_path)}]
       ])
 
-    {:os_pid, os_pid} = Port.info(port, :os_pid)
-    deadline = System.monotonic_time(:millisecond) + timeout
-    collect_exit(port, os_pid, deadline, max_output_bytes, [], 0)
+    monitor_ref = :erlang.monitor(:port, port)
+
+    case pid_lookup.(port) do
+      {:os_pid, os_pid} ->
+        deadline = System.monotonic_time(:millisecond) + timeout
+        collect_exit(port, monitor_ref, os_pid, deadline, max_output_bytes, [], 0)
+
+      nil ->
+        # The closed port can still have ordered data and exit messages in this mailbox.
+        # Drain them without a signal because an exact process identity is no longer available.
+        collect_exited_port(port, monitor_ref, max_output_bytes, [], 0, false)
+    end
   end
 
-  defp collect_exit(port, os_pid, deadline, max_output_bytes, stdout, observed_bytes) do
+  defp collect_exited_port(port, monitor_ref, max_output_bytes, stdout, observed_bytes, output_too_large?) do
+    receive do
+      {^port, {:data, data}} ->
+        observed_bytes = observed_bytes + byte_size(data)
+        output_too_large? = output_too_large?(max_output_bytes, observed_bytes)
+        stdout = if output_too_large?, do: [], else: [data | stdout]
+
+        collect_exited_port(port, monitor_ref, max_output_bytes, stdout, observed_bytes, output_too_large?)
+
+      {^port, {:exit_status, _status}} when output_too_large? ->
+        finish_exit_result(port, monitor_ref, nil, {:too_large, observed_bytes}, [], observed_bytes)
+
+      {^port, {:exit_status, status}} ->
+        stdout = Enum.reverse(stdout)
+
+        finish_exit_result(
+          port,
+          monitor_ref,
+          nil,
+          {:exit_status, status, stdout, observed_bytes},
+          stdout,
+          observed_bytes
+        )
+    after
+      @kill_wait_ms ->
+        {:error, reason} =
+          cleanup_failure(port, monitor_ref, nil, %{
+            reason: :exit_status_timeout
+          })
+
+        {:cleanup_failed, reason, Enum.reverse(stdout), observed_bytes}
+    end
+  end
+
+  defp output_too_large?(:infinity, _observed_bytes), do: false
+  defp output_too_large?(max_output_bytes, observed_bytes), do: observed_bytes > max_output_bytes
+
+  defp collect_exit(port, monitor_ref, os_pid, deadline, max_output_bytes, stdout, observed_bytes) do
     timeout = max(deadline - System.monotonic_time(:millisecond), 0)
 
     receive do
@@ -50,46 +117,72 @@ defmodule Jido.Browser.Vendor.BrowseyHttp.Util.Exec do
         observed_bytes = observed_bytes + byte_size(data)
 
         if max_output_bytes != :infinity and observed_bytes > max_output_bytes do
-          case terminate_and_reap(port, os_pid) do
+          case terminate_and_reap(port, monitor_ref, os_pid) do
             {:ok, _exit_status} -> {:too_large, observed_bytes}
             {:error, reason} -> {:cleanup_failed, reason, [], observed_bytes}
           end
         else
-          collect_exit(port, os_pid, deadline, max_output_bytes, [data | stdout], observed_bytes)
+          collect_exit(port, monitor_ref, os_pid, deadline, max_output_bytes, [data | stdout], observed_bytes)
         end
 
       {^port, {:exit_status, status}} ->
-        {:exit_status, status, Enum.reverse(stdout), observed_bytes}
+        stdout = Enum.reverse(stdout)
+
+        finish_exit_result(
+          port,
+          monitor_ref,
+          os_pid,
+          {:exit_status, status, stdout, observed_bytes},
+          stdout,
+          observed_bytes
+        )
     after
       timeout ->
-        case terminate_and_reap(port, os_pid) do
+        case terminate_and_reap(port, monitor_ref, os_pid) do
           {:ok, _exit_status} -> {:timeout, 28, Enum.reverse(stdout), observed_bytes}
           {:error, reason} -> {:cleanup_failed, reason, Enum.reverse(stdout), observed_bytes}
         end
     end
   end
 
-  defp terminate_and_reap(port, os_pid) do
-    term_result = signal_exact_port_process(port, os_pid, "TERM")
+  defp finish_exit_result(port, monitor_ref, os_pid, result, stdout, observed_bytes) do
+    deadline = System.monotonic_time(:millisecond) + @kill_wait_ms
 
-    case {term_result, await_exit(port, @term_wait_ms)} do
-      {_term_result, {:ok, exit_status}} ->
-        {:ok, exit_status}
+    case await_port_down(port, monitor_ref, deadline) do
+      :ok ->
+        result
 
-      {term_result, :timeout} ->
-        kill_and_reap(port, os_pid, term_result)
+      :timeout ->
+        {:error, reason} =
+          cleanup_failure(port, monitor_ref, os_pid, %{
+            reason: :port_reap_timeout
+          })
+
+        {:cleanup_failed, reason, stdout, observed_bytes}
     end
   end
 
-  defp kill_and_reap(port, os_pid, term_result) do
+  defp terminate_and_reap(port, monitor_ref, os_pid) do
+    term_result = signal_exact_port_process(port, os_pid, "TERM")
+
+    case {term_result, await_exit(port, monitor_ref, @term_wait_ms)} do
+      {_term_result, {:ok, exit_status}} ->
+        {:ok, exit_status}
+
+      {term_result, {:timeout, exit_status}} ->
+        kill_and_reap(port, monitor_ref, os_pid, term_result, exit_status)
+    end
+  end
+
+  defp kill_and_reap(port, monitor_ref, os_pid, term_result, exit_status) do
     kill_result = signal_exact_port_process(port, os_pid, "KILL")
 
-    case await_exit(port, @kill_wait_ms) do
+    case await_exit(port, monitor_ref, @kill_wait_ms, exit_status) do
       {:ok, exit_status} ->
         {:ok, exit_status}
 
-      :timeout ->
-        cleanup_failure(port, os_pid, %{
+      {:timeout, _exit_status} ->
+        cleanup_failure(port, monitor_ref, os_pid, %{
           kill_result: kill_result,
           reason: :kill_timeout,
           term_result: term_result
@@ -121,33 +214,64 @@ defmodule Jido.Browser.Vendor.BrowseyHttp.Util.Exec do
     error -> {:error, {:signal_failed, signal, os_pid, error}}
   end
 
-  defp await_exit(port, wait_ms) do
+  defp await_exit(port, monitor_ref, wait_ms, exit_status \\ nil) do
     deadline = System.monotonic_time(:millisecond) + wait_ms
-    await_exit(port, nil, deadline)
+    await_exit_until(port, monitor_ref, exit_status, deadline)
   end
 
-  defp await_exit(port, exit_status, deadline) do
-    if exit_status != nil and Port.info(port) == nil do
-      {:ok, exit_status}
+  defp await_exit_until(port, monitor_ref, exit_status, deadline) do
+    if exit_status != nil do
+      case await_port_down(port, monitor_ref, deadline) do
+        :ok -> {:ok, exit_status}
+        :timeout -> {:timeout, exit_status}
+      end
     else
       remaining = deadline - System.monotonic_time(:millisecond)
 
       if remaining <= 0 do
-        :timeout
+        {:timeout, nil}
       else
         receive do
-          {^port, {:data, _data}} -> await_exit(port, exit_status, deadline)
-          {^port, {:exit_status, status}} -> await_exit(port, status, deadline)
+          {^port, {:data, _data}} -> await_exit_until(port, monitor_ref, nil, deadline)
+          {^port, {:exit_status, status}} -> await_exit_until(port, monitor_ref, status, deadline)
         after
-          min(remaining, @cleanup_poll_ms) -> await_exit(port, exit_status, deadline)
+          min(remaining, @cleanup_poll_ms) -> await_exit_until(port, monitor_ref, nil, deadline)
         end
       end
     end
   end
 
-  defp cleanup_failure(port, os_pid, reason) do
+  # OTP sends exit_status before the port monitor DOWN. The port link EXIT signal
+  # is also delivered before DOWN. DOWN is therefore a safe mailbox barrier.
+  defp await_port_down(port, monitor_ref, deadline) do
+    remaining = deadline - System.monotonic_time(:millisecond)
+
+    if remaining <= 0 do
+      :timeout
+    else
+      receive do
+        {:DOWN, ^monitor_ref, :port, ^port, _reason} ->
+          flush_exact_port_exit(port)
+          :ok
+      after
+        remaining -> :timeout
+      end
+    end
+  end
+
+  defp flush_exact_port_exit(port) do
+    receive do
+      {:EXIT, ^port, _reason} -> flush_exact_port_exit(port)
+    after
+      0 -> :ok
+    end
+  end
+
+  defp cleanup_failure(port, monitor_ref, os_pid, reason) do
     port_open? = Port.info(port) != nil
     close_port(port)
+    cleanup_deadline = System.monotonic_time(:millisecond) + @kill_wait_ms
+    flush_closed_port(port, monitor_ref, cleanup_deadline)
 
     {:error,
      {:process_cleanup_failed,
@@ -156,6 +280,31 @@ defmodule Jido.Browser.Vendor.BrowseyHttp.Util.Exec do
         port_open?: port_open?,
         reason: reason
       }}}
+  end
+
+  defp flush_closed_port(port, monitor_ref, deadline) do
+    remaining = deadline - System.monotonic_time(:millisecond)
+
+    if remaining <= 0 do
+      :erlang.demonitor(monitor_ref, [:flush])
+      :timeout
+    else
+      receive do
+        {^port, {:data, _data}} ->
+          flush_closed_port(port, monitor_ref, deadline)
+
+        {^port, {:exit_status, _status}} ->
+          flush_closed_port(port, monitor_ref, deadline)
+
+        {:DOWN, ^monitor_ref, :port, ^port, _reason} ->
+          flush_exact_port_exit(port)
+          :ok
+      after
+        remaining ->
+          :erlang.demonitor(monitor_ref, [:flush])
+          :timeout
+      end
+    end
   end
 
   defp format_result({:exit_status, 0, stdout, _observed_bytes}, stderr_path) do


### PR DESCRIPTION
Closes #112

## Summary
- collect fast success and non-zero results when the port closes before OS PID discovery
- use a test-build-only PID lookup seam to exercise the real nil-PID state machine deterministically
- reap the exact owned port data, status, monitor, and EXIT messages without consuming unrelated EXIT messages
- keep exact-PID TERM, bounded wait, KILL, verified exit, and cleanup-failure behavior for timeout and response limits
- neutralize late test-fixture cleanup and require live port-to-PID ownership before any fallback signal
- preserve stdout/stderr separation and remove the exact temporary stderr file

## Validation
- 23 focused Browsey execution and response-limit tests passed
- 380 non-integration tests passed; 26 integration tests excluded
- compile with warnings as errors, format, Credo, Dialyzer, and Doctor passed
- docs, audit, unused dependencies, and Hex package dry run passed
- coverage passed at 68.4%
- AgentBrowser smoke passed
- the test seam is not exported in the development runtime
- no issue-owned sleep process remained for CI post-job cleanup