### PR TITLE
refactor(pool): remove adapter runtime dependency cycles

### DIFF
--- a/lib/jido_browser/adapters/agent_browser.ex
+++ b/lib/jido_browser/adapters/agent_browser.ex
@@ -475,7 +475,8 @@ defmodule Jido.Browser.Adapters.AgentBrowser do
           size: size,
           adapter: __MODULE__,
           worker_opts: session_opts,
-          pool_runtime_module: Keyword.get(opts, :pool_runtime_module, Jido.Browser.AgentBrowser.PoolRuntime)
+          pool_runtime_module: Keyword.get(opts, :pool_runtime_module, Jido.Browser.AgentBrowser.PoolRuntime),
+          pool_runtime_context: %{session_runtime_metadata: &Runtime.session_runtime_metadata/2}
         ] ++ pool_opts ++ extra_manager_opts
 
       startup_timeout =

--- a/lib/jido_browser/adapters/lightpanda.ex
+++ b/lib/jido_browser/adapters/lightpanda.ex
@@ -314,7 +314,11 @@ defmodule Jido.Browser.Adapters.Lightpanda do
           size: size,
           adapter: __MODULE__,
           worker_opts: Keyword.put(worker_opts, :pool_name, name),
-          pool_runtime_module: Keyword.get(opts, :pool_runtime_module, PoolRuntime)
+          pool_runtime_module: Keyword.get(opts, :pool_runtime_module, PoolRuntime),
+          pool_runtime_context: %{
+            start_connection: &start_connection/1,
+            stop_connection: &stop_connection/1
+          }
         ] ++ pool_opts
 
       startup_timeout =

--- a/lib/jido_browser/adapters/lightpanda/pool_runtime.ex
+++ b/lib/jido_browser/adapters/lightpanda/pool_runtime.ex
@@ -2,17 +2,21 @@ defmodule Jido.Browser.Adapters.Lightpanda.PoolRuntime do
   @moduledoc false
   @behaviour Jido.Browser.WarmPool.Runtime
 
-  alias Jido.Browser.Adapters.Lightpanda
+  alias Jido.Browser.WarmPool.Runtime, as: PoolRuntimeBoundary
 
   @impl true
   @spec start_worker(map()) :: {:ok, map()} | {:error, term()}
-  def start_worker(%{worker_opts: worker_opts}) do
+  def start_worker(%{worker_opts: worker_opts} = pool_state) do
     session_id = "lightpanda-pool-#{System.unique_integer([:positive])}"
+    runtime_context = PoolRuntimeBoundary.context(pool_state)
+    start_connection = Map.fetch!(runtime_context, :start_connection)
+    stop_connection = Map.fetch!(runtime_context, :stop_connection)
 
-    with {:ok, connection} <- Lightpanda.start_connection(worker_opts) do
+    with {:ok, connection} <- start_connection.(worker_opts) do
       {:ok,
        connection
        |> Map.put(:session_id, session_id)
+       |> Map.put(:pool_stop_connection, stop_connection)
        |> Map.put(:runtime, %{
          transport: :light_cdp,
          session_id: session_id
@@ -26,8 +30,8 @@ defmodule Jido.Browser.Adapters.Lightpanda.PoolRuntime do
 
   @impl true
   @spec shutdown_worker(map()) :: :ok | {:error, term()}
-  def shutdown_worker(worker_state) do
-    Lightpanda.stop_connection(worker_state)
+  def shutdown_worker(%{pool_stop_connection: stop_connection} = worker_state) do
+    stop_connection.(worker_state)
   end
 
   @impl true

--- a/lib/jido_browser/agent_browser/pool_runtime.ex
+++ b/lib/jido_browser/agent_browser/pool_runtime.ex
@@ -2,8 +2,8 @@ defmodule Jido.Browser.AgentBrowser.PoolRuntime do
   @moduledoc false
   @behaviour Jido.Browser.WarmPool.Runtime
 
-  alias Jido.Browser.AgentBrowser.Runtime
   alias Jido.Browser.AgentBrowser.SessionServer
+  alias Jido.Browser.WarmPool.Runtime, as: PoolRuntimeBoundary
 
   @type worker_state :: %{
           session_id: String.t(),
@@ -15,8 +15,10 @@ defmodule Jido.Browser.AgentBrowser.PoolRuntime do
 
   @doc false
   @spec start_worker(map()) :: {:ok, worker_state()} | {:error, term()}
-  def start_worker(%{worker_opts: session_opts, session_supervisor: session_supervisor}) do
+  def start_worker(%{worker_opts: session_opts, session_supervisor: session_supervisor} = pool_state) do
     session_id = Uniq.UUID.uuid4()
+    runtime_context = PoolRuntimeBoundary.context(pool_state)
+    session_runtime_metadata = Map.fetch!(runtime_context, :session_runtime_metadata)
 
     child_spec =
       {SessionServer,
@@ -32,7 +34,7 @@ defmodule Jido.Browser.AgentBrowser.PoolRuntime do
            binary: Keyword.fetch!(session_opts, :binary),
            manager: pid,
            health_check_timeout: Keyword.get(session_opts, :health_check_timeout, 2_000),
-           runtime: Runtime.session_runtime_metadata(session_id, pid)
+           runtime: session_runtime_metadata.(session_id, pid)
          }}
 
       {:error, {:already_started, pid}} ->
@@ -42,7 +44,7 @@ defmodule Jido.Browser.AgentBrowser.PoolRuntime do
            binary: Keyword.fetch!(session_opts, :binary),
            manager: pid,
            health_check_timeout: Keyword.get(session_opts, :health_check_timeout, 2_000),
-           runtime: Runtime.session_runtime_metadata(session_id, pid)
+           runtime: session_runtime_metadata.(session_id, pid)
          }}
 
       {:error, reason} ->

--- a/lib/jido_browser/agent_browser/protocol.ex
+++ b/lib/jido_browser/agent_browser/protocol.ex
@@ -1,0 +1,148 @@
+defmodule Jido.Browser.AgentBrowser.Protocol do
+  @moduledoc false
+
+  import Bitwise
+
+  @daemon_timeout 5_000
+
+  @type session_opts :: keyword()
+
+  @doc false
+  @spec default_daemon_timeout() :: pos_integer()
+  def default_daemon_timeout, do: @daemon_timeout
+
+  @doc false
+  @spec session_runtime_metadata(String.t(), pid()) :: map()
+  def session_runtime_metadata(session_id, pid) do
+    %{
+      transport: :agent_browser_ipc,
+      endpoint: endpoint(session_id),
+      manager: pid,
+      session_id: session_id
+    }
+  end
+
+  @doc false
+  @spec endpoint(String.t()) :: map()
+  def endpoint(session_id) do
+    if windows?() do
+      %{type: :tcp, host: "127.0.0.1", port: port_for_session(session_id)}
+    else
+      %{type: :unix, path: socket_path(session_id)}
+    end
+  end
+
+  @doc false
+  @spec socket_dir() :: String.t()
+  def socket_dir do
+    cond do
+      value = env("AGENT_BROWSER_SOCKET_DIR") ->
+        value
+
+      value = env("XDG_RUNTIME_DIR") ->
+        Path.join(value, "agent-browser")
+
+      home = System.user_home() ->
+        Path.join(home, ".agent-browser")
+
+      true ->
+        Path.join(System.tmp_dir!(), "agent-browser")
+    end
+  end
+
+  @doc false
+  @spec socket_path(String.t()) :: String.t()
+  def socket_path(session_id), do: Path.join(socket_dir(), "#{session_id}.sock")
+
+  @doc false
+  @spec pid_path(String.t()) :: String.t()
+  def pid_path(session_id), do: Path.join(socket_dir(), "#{session_id}.pid")
+
+  @doc false
+  @spec port_path(String.t()) :: String.t()
+  def port_path(session_id), do: Path.join(socket_dir(), "#{session_id}.port")
+
+  @doc false
+  @spec port_for_session(String.t()) :: pos_integer()
+  def port_for_session(session_id) do
+    hash =
+      session_id
+      |> String.to_charlist()
+      |> Enum.reduce(0, fn char, acc ->
+        Bitwise.band((acc <<< 5) - acc + char, 0xFFFFFFFF)
+      end)
+
+    49_152 + rem(abs(hash), 16_383)
+  end
+
+  @doc false
+  @spec daemon_env(String.t(), session_opts()) :: [{String.t(), String.t()}]
+  def daemon_env(session_id, opts) do
+    []
+    |> put_env("AGENT_BROWSER_DAEMON", "1")
+    |> put_env("AGENT_BROWSER_SESSION", session_id)
+    |> maybe_put_bool_env("AGENT_BROWSER_HEADED", Keyword.get(opts, :headed, false))
+    |> maybe_put_bool_env("AGENT_BROWSER_DEBUG", Keyword.get(opts, :debug, false))
+    |> maybe_put("AGENT_BROWSER_EXECUTABLE_PATH", Keyword.get(opts, :executable_path))
+    |> maybe_put("AGENT_BROWSER_SESSION_NAME", Keyword.get(opts, :session_name))
+    |> maybe_put("AGENT_BROWSER_DOWNLOAD_PATH", Keyword.get(opts, :download_path))
+    |> maybe_put("AGENT_BROWSER_COLOR_SCHEME", Keyword.get(opts, :color_scheme))
+    |> maybe_put("AGENT_BROWSER_ENGINE", Keyword.get(opts, :engine))
+    |> maybe_put_timeout("AGENT_BROWSER_DEFAULT_TIMEOUT", Keyword.get(opts, :timeout))
+    |> maybe_put_list("AGENT_BROWSER_ALLOWED_DOMAINS", Keyword.get(opts, :allowed_domains))
+  end
+
+  @doc false
+  @spec request_id() :: String.t()
+  def request_id, do: Uniq.UUID.uuid4()
+
+  @doc false
+  @spec connect(String.t(), pos_integer()) :: {:ok, port()} | {:error, term()}
+  def connect(session_id, timeout) do
+    if windows?() do
+      :gen_tcp.connect(~c"127.0.0.1", port_for_session(session_id), tcp_options(), timeout)
+    else
+      :gen_tcp.connect({:local, socket_path(session_id)}, 0, tcp_options(), timeout)
+    end
+  end
+
+  @doc false
+  @spec tcp_options() :: [:binary | {:active, false} | {:packet, :line}]
+  def tcp_options, do: [:binary, packet: :line, active: false]
+
+  @doc false
+  @spec windows?() :: boolean()
+  def windows?, do: match?({:win32, _}, :os.type())
+
+  @doc false
+  @spec config(atom(), term()) :: term()
+  def config(key, default \\ nil) do
+    :jido_browser
+    |> Application.get_env(:agent_browser, [])
+    |> Keyword.get(key, default)
+  end
+
+  defp env(var) do
+    case System.get_env(var) do
+      nil -> nil
+      "" -> nil
+      value -> value
+    end
+  end
+
+  defp put_env(acc, key, value), do: [{key, value} | acc]
+
+  defp maybe_put(acc, _key, nil), do: acc
+  defp maybe_put(acc, _key, ""), do: acc
+  defp maybe_put(acc, key, value), do: [{key, to_string(value)} | acc]
+
+  defp maybe_put_bool_env(acc, _key, false), do: acc
+  defp maybe_put_bool_env(acc, key, true), do: [{key, "1"} | acc]
+
+  defp maybe_put_timeout(acc, _key, nil), do: acc
+  defp maybe_put_timeout(acc, key, timeout), do: [{key, to_string(timeout)} | acc]
+
+  defp maybe_put_list(acc, _key, nil), do: acc
+  defp maybe_put_list(acc, _key, []), do: acc
+  defp maybe_put_list(acc, key, value), do: [{key, Enum.join(value, ",")} | acc]
+end

--- a/lib/jido_browser/agent_browser/runtime.ex
+++ b/lib/jido_browser/agent_browser/runtime.ex
@@ -1,13 +1,11 @@
 defmodule Jido.Browser.AgentBrowser.Runtime do
   @moduledoc false
 
-  import Bitwise
-
   alias Jido.Browser.AgentBrowser.Binary
+  alias Jido.Browser.AgentBrowser.Protocol
   alias Jido.Browser.Application, as: BrowserApplication
-  alias Jido.Browser.Installer
+  alias Jido.Browser.Installer.Paths
 
-  @daemon_timeout 5_000
   @command_timeout 30_000
 
   @type session_opts :: keyword()
@@ -31,7 +29,7 @@ defmodule Jido.Browser.AgentBrowser.Runtime do
 
   @doc false
   @spec default_daemon_timeout() :: pos_integer()
-  def default_daemon_timeout, do: @daemon_timeout
+  defdelegate default_daemon_timeout(), to: Protocol
 
   @doc false
   @spec capabilities() :: map()
@@ -39,7 +37,7 @@ defmodule Jido.Browser.AgentBrowser.Runtime do
 
   @doc false
   @spec find_binary() :: {:ok, String.t()} | {:error, term()}
-  def find_binary, do: Binary.resolve(Installer.agent_browser_package_path())
+  def find_binary, do: Binary.resolve(Paths.agent_browser_package_path())
 
   @doc false
   @spec ensure_supported_version(String.t()) :: :ok | {:error, term()}
@@ -68,138 +66,55 @@ defmodule Jido.Browser.AgentBrowser.Runtime do
 
   @doc false
   @spec session_runtime_metadata(String.t(), pid()) :: map()
-  def session_runtime_metadata(session_id, pid) do
-    %{
-      transport: :agent_browser_ipc,
-      endpoint: endpoint(session_id),
-      manager: pid,
-      session_id: session_id
-    }
-  end
+  defdelegate session_runtime_metadata(session_id, pid), to: Protocol
 
   @doc false
   @spec endpoint(String.t()) :: map()
-  def endpoint(session_id) do
-    if windows?() do
-      %{type: :tcp, host: "127.0.0.1", port: port_for_session(session_id)}
-    else
-      %{type: :unix, path: socket_path(session_id)}
-    end
-  end
+  defdelegate endpoint(session_id), to: Protocol
 
   @doc false
   @spec socket_dir() :: String.t()
-  def socket_dir do
-    cond do
-      value = env("AGENT_BROWSER_SOCKET_DIR") ->
-        value
-
-      value = env("XDG_RUNTIME_DIR") ->
-        Path.join(value, "agent-browser")
-
-      home = System.user_home() ->
-        Path.join(home, ".agent-browser")
-
-      true ->
-        Path.join(System.tmp_dir!(), "agent-browser")
-    end
-  end
+  defdelegate socket_dir(), to: Protocol
 
   @doc false
   @spec socket_path(String.t()) :: String.t()
-  def socket_path(session_id), do: Path.join(socket_dir(), "#{session_id}.sock")
+  defdelegate socket_path(session_id), to: Protocol
 
   @doc false
   @spec pid_path(String.t()) :: String.t()
-  def pid_path(session_id), do: Path.join(socket_dir(), "#{session_id}.pid")
+  defdelegate pid_path(session_id), to: Protocol
 
   @doc false
   @spec port_path(String.t()) :: String.t()
-  def port_path(session_id), do: Path.join(socket_dir(), "#{session_id}.port")
+  defdelegate port_path(session_id), to: Protocol
 
   @doc false
   @spec port_for_session(String.t()) :: pos_integer()
-  def port_for_session(session_id) do
-    hash =
-      session_id
-      |> String.to_charlist()
-      |> Enum.reduce(0, fn char, acc ->
-        Bitwise.band((acc <<< 5) - acc + char, 0xFFFFFFFF)
-      end)
-
-    49_152 + rem(abs(hash), 16_383)
-  end
+  defdelegate port_for_session(session_id), to: Protocol
 
   @doc false
   @spec daemon_env(String.t(), session_opts()) :: [{String.t(), String.t()}]
-  def daemon_env(session_id, opts) do
-    []
-    |> put_env("AGENT_BROWSER_DAEMON", "1")
-    |> put_env("AGENT_BROWSER_SESSION", session_id)
-    |> maybe_put_bool_env("AGENT_BROWSER_HEADED", Keyword.get(opts, :headed, false))
-    |> maybe_put_bool_env("AGENT_BROWSER_DEBUG", Keyword.get(opts, :debug, false))
-    |> maybe_put("AGENT_BROWSER_EXECUTABLE_PATH", Keyword.get(opts, :executable_path))
-    |> maybe_put("AGENT_BROWSER_SESSION_NAME", Keyword.get(opts, :session_name))
-    |> maybe_put("AGENT_BROWSER_DOWNLOAD_PATH", Keyword.get(opts, :download_path))
-    |> maybe_put("AGENT_BROWSER_COLOR_SCHEME", Keyword.get(opts, :color_scheme))
-    |> maybe_put("AGENT_BROWSER_ENGINE", Keyword.get(opts, :engine))
-    |> maybe_put_timeout("AGENT_BROWSER_DEFAULT_TIMEOUT", Keyword.get(opts, :timeout))
-    |> maybe_put_list("AGENT_BROWSER_ALLOWED_DOMAINS", Keyword.get(opts, :allowed_domains))
-  end
+  defdelegate daemon_env(session_id, opts), to: Protocol
 
   @doc false
   @spec request_id() :: String.t()
-  def request_id, do: Uniq.UUID.uuid4()
+  defdelegate request_id(), to: Protocol
 
   @doc false
   @spec connect(String.t(), pos_integer()) :: {:ok, port()} | {:error, term()}
-  def connect(session_id, timeout) do
-    if windows?() do
-      :gen_tcp.connect(~c"127.0.0.1", port_for_session(session_id), tcp_options(), timeout)
-    else
-      :gen_tcp.connect({:local, socket_path(session_id)}, 0, tcp_options(), timeout)
-    end
-  end
+  defdelegate connect(session_id, timeout), to: Protocol
 
   @doc false
   @spec tcp_options() :: [:binary | {:active, false} | {:packet, :line}]
-  def tcp_options, do: [:binary, packet: :line, active: false]
+  defdelegate tcp_options(), to: Protocol
 
   @doc false
   @spec windows?() :: boolean()
-  def windows?, do: match?({:win32, _}, :os.type())
+  defdelegate windows?(), to: Protocol
 
   @doc false
   @spec config(atom(), term()) :: term()
-  def config(key, default \\ nil) do
-    :jido_browser
-    |> Application.get_env(:agent_browser, [])
-    |> Keyword.get(key, default)
-  end
-
-  defp env(var) do
-    case System.get_env(var) do
-      nil -> nil
-      "" -> nil
-      value -> value
-    end
-  end
-
-  defp put_env(acc, key, value), do: [{key, value} | acc]
-
-  defp maybe_put(acc, _key, nil), do: acc
-  defp maybe_put(acc, _key, ""), do: acc
-  defp maybe_put(acc, key, value), do: [{key, to_string(value)} | acc]
-
-  defp maybe_put_bool_env(acc, _key, false), do: acc
-  defp maybe_put_bool_env(acc, key, true), do: [{key, "1"} | acc]
-
-  defp maybe_put_timeout(acc, _key, nil), do: acc
-  defp maybe_put_timeout(acc, key, timeout), do: [{key, to_string(timeout)} | acc]
-
-  defp maybe_put_list(acc, _key, nil), do: acc
-  defp maybe_put_list(acc, _key, []), do: acc
-  defp maybe_put_list(acc, key, value), do: [{key, Enum.join(value, ",")} | acc]
+  def config(key, default \\ nil), do: Protocol.config(key, default)
 
   defp do_ensure_session_server(session_id, opts, retries_left) do
     case lookup_session_server(session_id) do

--- a/lib/jido_browser/agent_browser/session_server.ex
+++ b/lib/jido_browser/agent_browser/session_server.ex
@@ -3,7 +3,7 @@ defmodule Jido.Browser.AgentBrowser.SessionServer do
 
   use GenServer
 
-  alias Jido.Browser.AgentBrowser.Runtime
+  alias Jido.Browser.AgentBrowser.Protocol
 
   @startup_attempts 50
   @startup_interval 100
@@ -79,7 +79,7 @@ defmodule Jido.Browser.AgentBrowser.SessionServer do
 
     session_id = Keyword.fetch!(opts, :session_id)
     binary = Keyword.fetch!(opts, :binary)
-    endpoint = Runtime.endpoint(session_id)
+    endpoint = Protocol.endpoint(session_id)
 
     state = %__MODULE__{
       session_id: session_id,
@@ -101,7 +101,7 @@ defmodule Jido.Browser.AgentBrowser.SessionServer do
 
   @impl true
   def handle_call(:metadata, _from, state) do
-    {:reply, Runtime.session_runtime_metadata(state.session_id, self()), state}
+    {:reply, Protocol.session_runtime_metadata(state.session_id, self()), state}
   end
 
   def handle_call({:command, payload, timeout}, _from, state) do
@@ -142,13 +142,13 @@ defmodule Jido.Browser.AgentBrowser.SessionServer do
   end
 
   defp ensure_socket_dir do
-    File.mkdir_p(Runtime.socket_dir())
+    File.mkdir_p(Protocol.socket_dir())
   end
 
   defp start_daemon(state) do
     env =
       state.session_id
-      |> Runtime.daemon_env(state.opts)
+      |> Protocol.daemon_env(state.opts)
       |> Enum.map(fn {key, value} ->
         {String.to_charlist(key), String.to_charlist(value)}
       end)
@@ -195,16 +195,16 @@ defmodule Jido.Browser.AgentBrowser.SessionServer do
   end
 
   defp ping(state) do
-    payload = %{"id" => Runtime.request_id(), "action" => "title"}
+    payload = %{"id" => Protocol.request_id(), "action" => "title"}
 
-    case do_dispatch(payload, Runtime.default_daemon_timeout(), state) do
+    case do_dispatch(payload, Protocol.default_daemon_timeout(), state) do
       {:ok, data} -> {:ok, data}
       {:error, _reason} -> {:error, :not_ready}
     end
   end
 
   defp dispatch(payload, timeout, state, attempts_left) do
-    payload = Map.put_new(payload, "id", Runtime.request_id())
+    payload = Map.put_new(payload, "id", Protocol.request_id())
 
     case do_dispatch(payload, timeout, state) do
       {:ok, _data} = ok ->
@@ -221,7 +221,7 @@ defmodule Jido.Browser.AgentBrowser.SessionServer do
   end
 
   defp do_dispatch(payload, timeout, state) do
-    case Runtime.connect(state.session_id, Runtime.default_daemon_timeout()) do
+    case Protocol.connect(state.session_id, Protocol.default_daemon_timeout()) do
       {:ok, socket} ->
         try do
           case send_payload(socket, payload, timeout) do

--- a/lib/jido_browser/deprecations.ex
+++ b/lib/jido_browser/deprecations.ex
@@ -5,10 +5,12 @@ defmodule Jido.Browser.Deprecations do
 
   require Logger
 
-  @agent_browser Jido.Browser.Adapters.AgentBrowser
-  @browsey_backend Jido.Browser.WebFetch.Backends.Browsey
+  # Literal module atoms preserve exact selections without compile dependencies.
+  @agent_browser :"Elixir.Jido.Browser.Adapters.AgentBrowser"
+  @browsey_backend :"Elixir.Jido.Browser.WebFetch.Backends.Browsey"
+  @browsey_http :"Elixir.Jido.Browser.Vendor.BrowseyHttp"
   @state_key {__MODULE__, :boot_warning_state}
-  @web_adapter Jido.Browser.Adapters.Web
+  @web_adapter :"Elixir.Jido.Browser.Adapters.Web"
 
   @web_warning "#{inspect(@web_adapter)} (the Web adapter runtime) is deprecated and will be removed in " <>
                  "Jido Browser 3.0. Use #{inspect(@agent_browser)} instead."
@@ -78,7 +80,7 @@ defmodule Jido.Browser.Deprecations do
   defp deprecation(@web_adapter), do: {:web, @web_warning}
   defp deprecation(:web), do: {:web, @web_warning}
   defp deprecation(@browsey_backend), do: {:browsey, @browsey_warning}
-  defp deprecation(Jido.Browser.Vendor.BrowseyHttp), do: {:browsey, @browsey_warning}
+  defp deprecation(@browsey_http), do: {:browsey, @browsey_warning}
   defp deprecation(:browsey), do: {:browsey, @browsey_warning}
   defp deprecation(_selection), do: nil
 

--- a/lib/jido_browser/installer.ex
+++ b/lib/jido_browser/installer.ex
@@ -32,6 +32,7 @@ defmodule Jido.Browser.Installer do
   require Logger
 
   alias Jido.Browser.AgentBrowser.Binary
+  alias Jido.Browser.Installer.Paths
 
   @vibium_version "26.3.11"
   @web_version "main"
@@ -41,6 +42,13 @@ defmodule Jido.Browser.Installer do
     web: ["--help"],
     lightpanda: ["version"]
   }
+  # Literal module atoms preserve exact selections without an xref edge to adapters.
+  @adapter_binaries %{
+    :"Elixir.Jido.Browser.Adapters.AgentBrowser" => :agent_browser,
+    :"Elixir.Jido.Browser.Adapters.Lightpanda" => :lightpanda,
+    :"Elixir.Jido.Browser.Adapters.Vibium" => :vibium,
+    :"Elixir.Jido.Browser.Adapters.Web" => :web
+  }
 
   @type platform :: :darwin_arm64 | :darwin_amd64 | :linux_amd64 | :linux_arm64 | :windows_amd64
 
@@ -48,11 +56,7 @@ defmodule Jido.Browser.Installer do
   Returns the detected platform for the current system.
   """
   @spec target() :: platform()
-  def target do
-    os = detect_os()
-    arch = detect_arch()
-    :"#{os}_#{arch}"
-  end
+  defdelegate target(), to: Paths
 
   @doc """
   Returns whether a given binary is installed and available.
@@ -144,19 +148,11 @@ defmodule Jido.Browser.Installer do
   same pattern as Phoenix's Tailwind installer.
   """
   @spec default_install_path() :: String.t()
-  def default_install_path do
-    if path = Application.get_env(:jido_browser, :path) do
-      Path.expand(path)
-    else
-      Path.join(Path.dirname(Mix.Project.build_path()), "jido_browser-#{target()}")
-    end
-  end
+  defdelegate default_install_path(), to: Paths
 
   @doc false
   @spec agent_browser_package_path() :: String.t()
-  def agent_browser_package_path do
-    Path.join(default_install_path(), agent_browser_binary_name())
-  end
+  defdelegate agent_browser_package_path(), to: Paths
 
   @doc """
   Returns the configured version for a binary.
@@ -171,16 +167,12 @@ defmodule Jido.Browser.Installer do
   # Private implementation
 
   defp configured_adapter_binary do
-    adapter = Application.get_env(:jido_browser, :adapter, Jido.Browser.Adapters.AgentBrowser)
-
-    case adapter do
-      Jido.Browser.Adapters.AgentBrowser -> :agent_browser
-      Jido.Browser.Adapters.Vibium -> :vibium
-      Jido.Browser.Adapters.Web -> :web
-      Jido.Browser.Adapters.Lightpanda -> :lightpanda
-      _ -> :agent_browser
-    end
+    :jido_browser
+    |> Application.get_env(:adapter, :"Elixir.Jido.Browser.Adapters.AgentBrowser")
+    |> adapter_binary()
   end
+
+  defp adapter_binary(adapter), do: Map.get(@adapter_binaries, adapter, :agent_browser)
 
   defp agent_browser_installed? do
     match?({:ok, _path}, resolve_agent_browser())
@@ -517,15 +509,7 @@ defmodule Jido.Browser.Installer do
     end
   end
 
-  defp agent_browser_binary_name do
-    case target() do
-      :darwin_arm64 -> "agent-browser-darwin-arm64"
-      :darwin_amd64 -> "agent-browser-darwin-x64"
-      :linux_amd64 -> "agent-browser-linux-x64"
-      :linux_arm64 -> "agent-browser-linux-arm64"
-      :windows_amd64 -> "agent-browser-win32-x64.exe"
-    end
-  end
+  defp agent_browser_binary_name, do: Paths.agent_browser_binary_name()
 
   defp agent_browser_download_url do
     version = configured_version(:agent_browser)
@@ -770,28 +754,4 @@ defmodule Jido.Browser.Installer do
         {:error, inspect(reason)}
     end
   end
-
-  # Platform detection
-
-  defp detect_os do
-    case :os.type() do
-      {:unix, :darwin} -> :darwin
-      {:unix, :linux} -> :linux
-      {:win32, _} -> :windows
-      other -> other
-    end
-  end
-
-  defp detect_arch do
-    :erlang.system_info(:system_architecture)
-    |> to_string()
-    |> parse_arch()
-  end
-
-  defp parse_arch("aarch64" <> _), do: :arm64
-  defp parse_arch("arm64" <> _), do: :arm64
-  defp parse_arch("x86_64" <> _), do: :amd64
-  defp parse_arch("amd64" <> _), do: :amd64
-  defp parse_arch("win32" <> _), do: :amd64
-  defp parse_arch(_other), do: :amd64
 end

--- a/lib/jido_browser/installer/paths.ex
+++ b/lib/jido_browser/installer/paths.ex
@@ -1,0 +1,63 @@
+defmodule Jido.Browser.Installer.Paths do
+  @moduledoc false
+
+  @type platform :: :darwin_arm64 | :darwin_amd64 | :linux_amd64 | :linux_arm64 | :windows_amd64
+
+  @doc false
+  @spec target() :: platform()
+  def target do
+    os = detect_os()
+    arch = detect_arch()
+    :"#{os}_#{arch}"
+  end
+
+  @doc false
+  @spec default_install_path() :: String.t()
+  def default_install_path do
+    if path = Application.get_env(:jido_browser, :path) do
+      Path.expand(path)
+    else
+      Path.join(Path.dirname(Mix.Project.build_path()), "jido_browser-#{target()}")
+    end
+  end
+
+  @doc false
+  @spec agent_browser_package_path() :: String.t()
+  def agent_browser_package_path do
+    Path.join(default_install_path(), agent_browser_binary_name())
+  end
+
+  @doc false
+  @spec agent_browser_binary_name() :: String.t()
+  def agent_browser_binary_name do
+    case target() do
+      :darwin_arm64 -> "agent-browser-darwin-arm64"
+      :darwin_amd64 -> "agent-browser-darwin-x64"
+      :linux_amd64 -> "agent-browser-linux-x64"
+      :linux_arm64 -> "agent-browser-linux-arm64"
+      :windows_amd64 -> "agent-browser-win32-x64.exe"
+    end
+  end
+
+  defp detect_os do
+    case :os.type() do
+      {:unix, :darwin} -> :darwin
+      {:unix, :linux} -> :linux
+      {:win32, _} -> :windows
+      other -> other
+    end
+  end
+
+  defp detect_arch do
+    :erlang.system_info(:system_architecture)
+    |> to_string()
+    |> parse_arch()
+  end
+
+  defp parse_arch("aarch64" <> _), do: :arm64
+  defp parse_arch("arm64" <> _), do: :arm64
+  defp parse_arch("x86_64" <> _), do: :amd64
+  defp parse_arch("amd64" <> _), do: :amd64
+  defp parse_arch("win32" <> _), do: :amd64
+  defp parse_arch(_other), do: :amd64
+end

--- a/lib/jido_browser/warm_pool/manager.ex
+++ b/lib/jido_browser/warm_pool/manager.ex
@@ -132,6 +132,7 @@ defmodule Jido.Browser.WarmPool.Manager do
     session_supervisor = Keyword.fetch!(opts, :session_supervisor)
     lease_supervisor = Keyword.fetch!(opts, :lease_supervisor)
     cleanup_supervisor = Keyword.fetch!(opts, :cleanup_supervisor)
+    runtime_context = Keyword.get(opts, :pool_runtime_context)
     lifecycle = Keyword.get(opts, :lifecycle, :ephemeral)
     max_uses = Keyword.get(opts, :max_uses)
     max_age_ms = Keyword.get(opts, :max_age_ms)
@@ -147,6 +148,7 @@ defmodule Jido.Browser.WarmPool.Manager do
              session_supervisor: session_supervisor,
              cleanup_supervisor: cleanup_supervisor,
              runtime_module: runtime_module,
+             runtime_context: runtime_context,
              lifecycle: lifecycle,
              max_uses: max_uses,
              max_age_ms: max_age_ms

--- a/lib/jido_browser/warm_pool/runtime.ex
+++ b/lib/jido_browser/warm_pool/runtime.ex
@@ -1,12 +1,21 @@
 defmodule Jido.Browser.WarmPool.Runtime do
   @moduledoc false
 
-  @callback start_worker(map()) :: {:ok, map()} | {:error, term()}
+  @type pool_state :: %{
+          required(:worker_opts) => keyword(),
+          optional(atom()) => term()
+        }
+
+  @callback start_worker(pool_state()) :: {:ok, map()} | {:error, term()}
   @callback command(map(), map(), pos_integer()) :: {:ok, map()} | {:error, term()}
   @callback shutdown_worker(map()) :: :ok | {:error, term()}
   @callback health_check(map()) :: :ok | {:error, term()}
 
   @optional_callbacks health_check: 1
+
+  @doc false
+  @spec context(pool_state()) :: term()
+  def context(pool_state), do: Map.get(pool_state, :runtime_context)
 
   @doc false
   @spec healthy?(module(), map()) :: :ok | {:error, term()}

--- a/test/jido_browser/adapters/lightpanda_test.exs
+++ b/test/jido_browser/adapters/lightpanda_test.exs
@@ -150,6 +150,10 @@ defmodule Jido.Browser.Adapters.LightpandaTest do
           assert {:ok, session} = Browser.start_session(adapter: Lightpanda, pool: pool_name)
           assert session.adapter == Lightpanda
           assert session.runtime.pooled == true
+          assert session.runtime.pool == pool_name
+          assert session.runtime.manager_module == Jido.Browser.WarmPool.Lease
+          assert session.opts.checkout_timeout == 5_000
+          assert String.starts_with?(session.runtime.session_id, "lightpanda-pool-")
           assert session.connection.cdp_session == first_cdp_session
 
           assert {:ok, session, %{url: "https://example.com"}} =

--- a/test/jido_browser/agent_browser_runtime_test.exs
+++ b/test/jido_browser/agent_browser_runtime_test.exs
@@ -7,6 +7,7 @@ defmodule Jido.Browser.AgentBrowserRuntimeTest do
   alias Jido.Browser.AgentBrowser.SessionServer
   alias Jido.Browser.Application, as: BrowserApplication
   alias Jido.Browser.TestSupport.FakeAgentBrowser
+  alias Jido.Browser.WarmPool.Names
 
   describe "application bootstrap" do
     test "ensure_started restarts the browser application after it has been stopped" do
@@ -132,6 +133,49 @@ defmodule Jido.Browser.AgentBrowserRuntimeTest do
   end
 
   describe "pool runtime" do
+    test "the AgentBrowser adapter wires the default pool runtime and keeps pool registration" do
+      FakeAgentBrowser.with_binary(:normal, fn binary, _socket_dir ->
+        with_agent_browser_config([binary_path: binary], fn ->
+          name = "agent-browser-runtime-#{System.unique_integer([:positive])}"
+
+          assert {:ok, pool} =
+                   Jido.Browser.start_pool(
+                     adapter: AgentBrowser,
+                     name: name,
+                     size: 1,
+                     timeout: 1_000,
+                     startup_timeout: 5_000
+                   )
+
+          try do
+            assert {:ok, ^pool} = Names.resolve_tree(name)
+            assert {:ok, manager} = Names.resolve_manager(name)
+            assert Process.alive?(manager)
+
+            assert {:ok, session} = Jido.Browser.start_session(adapter: AgentBrowser, pool: name)
+            assert session.adapter == AgentBrowser
+            assert session.runtime.pool == name
+            assert session.runtime.pooled == true
+            assert session.runtime.manager_module == Jido.Browser.WarmPool.Lease
+            assert session.opts.checkout_timeout == 5_000
+            assert :error = Runtime.lookup_session_server(session.runtime.session_id)
+
+            assert {:ok, ^session, %{"title" => "Ready", "url" => nil}} =
+                     Jido.Browser.get_title(session, timeout: 1_000)
+
+            assert :ok = Jido.Browser.end_session(session)
+          after
+            assert :ok = Jido.Browser.stop_pool(pool)
+          end
+
+          assert_eventually(fn ->
+            assert {:error, :pool_not_found} = Names.resolve_tree(name)
+            assert {:error, :pool_not_found} = Names.resolve_manager(name)
+          end)
+        end)
+      end)
+    end
+
     test "starts a pool-local worker, dispatches commands, and shuts it down" do
       FakeAgentBrowser.with_binary(:normal, fn binary, _socket_dir ->
         session_supervisor = start_supervised!({DynamicSupervisor, strategy: :one_for_one})
@@ -139,8 +183,21 @@ defmodule Jido.Browser.AgentBrowserRuntimeTest do
         assert {:ok, worker_state} =
                  PoolRuntime.start_worker(%{
                    worker_opts: [binary: binary, timeout: 1_000],
-                   session_supervisor: session_supervisor
+                   session_supervisor: session_supervisor,
+                   runtime_context: %{session_runtime_metadata: &Runtime.session_runtime_metadata/2}
                  })
+
+        assert worker_state.binary == binary
+        assert worker_state.health_check_timeout == 2_000
+        assert worker_state.runtime.transport == :agent_browser_ipc
+        assert worker_state.runtime.session_id == worker_state.session_id
+        assert worker_state.runtime.manager == worker_state.manager
+        assert :error = Runtime.lookup_session_server(worker_state.session_id)
+
+        assert Enum.any?(DynamicSupervisor.which_children(session_supervisor), fn
+                 {_id, pid, :worker, [SessionServer]} -> pid == worker_state.manager
+                 _child -> false
+               end)
 
         assert :ok = PoolRuntime.health_check(worker_state)
 
@@ -152,6 +209,7 @@ defmodule Jido.Browser.AgentBrowserRuntimeTest do
         assert :ok = PoolRuntime.shutdown_worker(worker_state)
         assert_receive {:DOWN, ^ref, :process, ^manager, :normal}, 1_000
         assert {:error, :session_unavailable} = PoolRuntime.health_check(worker_state)
+        assert DynamicSupervisor.which_children(session_supervisor) == []
       end)
     end
   end
@@ -261,5 +319,19 @@ defmodule Jido.Browser.AgentBrowserRuntimeTest do
     after
       Process.flag(:trap_exit, old)
     end
+  end
+
+  defp assert_eventually(fun, attempts \\ 100)
+
+  defp assert_eventually(fun, attempts) when attempts > 0 do
+    fun.()
+  rescue
+    error ->
+      if attempts == 1 do
+        reraise error, __STACKTRACE__
+      else
+        Process.sleep(10)
+        assert_eventually(fun, attempts - 1)
+      end
   end
 end

--- a/test/jido_browser/installer_adapter_selection_test.exs
+++ b/test/jido_browser/installer_adapter_selection_test.exs
@@ -1,0 +1,74 @@
+defmodule Jido.Browser.InstallerAdapterSelectionTest do
+  use ExUnit.Case, async: false
+
+  alias Jido.Browser.Adapters.AgentBrowser
+  alias Jido.Browser.Adapters.Lightpanda
+  alias Jido.Browser.Adapters.Vibium
+  alias Jido.Browser.Adapters.Web
+  alias Jido.Browser.Installer
+
+  @config_keys [:adapter, :agent_browser, :lightpanda, :vibium, :web]
+
+  setup do
+    previous = Map.new(@config_keys, &{&1, Application.get_env(:jido_browser, &1, :__missing__)})
+    path = temporary_browser_command()
+
+    on_exit(fn ->
+      Enum.each(previous, fn
+        {key, :__missing__} -> Application.delete_env(:jido_browser, key)
+        {key, value} -> Application.put_env(:jido_browser, key, value)
+      end)
+
+      File.rm_rf(Path.dirname(path))
+    end)
+
+    {:ok, path: path}
+  end
+
+  test "configured adapter modules keep their installer target", %{path: path} do
+    cases = [
+      {AgentBrowser, :agent_browser},
+      {Lightpanda, :lightpanda},
+      {Vibium, :vibium},
+      {Web, :web}
+    ]
+
+    Enum.each(cases, fn {adapter, config_key} ->
+      set_missing_adapter_paths()
+      Application.put_env(:jido_browser, :adapter, adapter)
+      Application.put_env(:jido_browser, config_key, binary_path: path)
+
+      assert :ok = Installer.ensure_installed()
+    end)
+  end
+
+  test "unknown configured adapters keep the AgentBrowser installer default", %{path: path} do
+    set_missing_adapter_paths()
+    Application.put_env(:jido_browser, :adapter, __MODULE__)
+    Application.put_env(:jido_browser, :agent_browser, binary_path: path)
+
+    assert :ok = Installer.ensure_installed()
+  end
+
+  defp set_missing_adapter_paths do
+    missing = Path.join(System.tmp_dir!(), "jido_browser_missing_#{System.unique_integer([:positive])}")
+
+    for key <- [:agent_browser, :lightpanda, :vibium, :web] do
+      Application.put_env(:jido_browser, key, binary_path: missing)
+    end
+  end
+
+  defp temporary_browser_command do
+    directory = Path.join(System.tmp_dir!(), "jido_browser_selection_#{System.unique_integer([:positive])}")
+    path = Path.join(directory, "browser-command")
+    File.mkdir_p!(directory)
+
+    File.write!(
+      path,
+      "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then printf 'agent-browser 0.35.1\\n'; fi\nexit 0\n"
+    )
+
+    File.chmod!(path, 0o755)
+    path
+  end
+end

--- a/test/jido_browser/pool_dependency_direction_test.exs
+++ b/test/jido_browser/pool_dependency_direction_test.exs
@@ -1,0 +1,95 @@
+defmodule Jido.Browser.PoolDependencyDirectionTest do
+  use ExUnit.Case, async: false
+
+  alias Mix.Tasks.Xref
+
+  @agent_browser_adapter "lib/jido_browser/adapters/agent_browser.ex"
+  @agent_browser_pool_runtime "lib/jido_browser/agent_browser/pool_runtime.ex"
+  @lightpanda_adapter "lib/jido_browser/adapters/lightpanda.ex"
+  @lightpanda_pool_runtime "lib/jido_browser/adapters/lightpanda/pool_runtime.ex"
+  @target_files [
+    @agent_browser_adapter,
+    @agent_browser_pool_runtime,
+    @lightpanda_adapter,
+    @lightpanda_pool_runtime
+  ]
+
+  setup_all do
+    {:ok, graph: xref_graph()}
+  end
+
+  test "all adapter and pool runtime nodes are present in the xref graph", %{graph: graph} do
+    assert_target_nodes_present(graph)
+  end
+
+  test "target presence guard fails when a target node is removed", %{graph: graph} do
+    graph_without_target = Map.delete(graph, @lightpanda_pool_runtime)
+
+    assert_raise ExUnit.AssertionError, ~r/expected xref graph to contain .*lightpanda\/pool_runtime\.ex/, fn ->
+      assert_target_nodes_present(graph_without_target)
+    end
+  end
+
+  test "adapter pool runtimes cannot reach back into their adapters", %{graph: graph} do
+    refute dependency_path?(graph, @agent_browser_pool_runtime, @agent_browser_adapter)
+    refute dependency_path?(graph, @lightpanda_pool_runtime, @lightpanda_adapter)
+  end
+
+  test "the Browser and FetchRich cycle stays assigned to issue 92", %{graph: graph} do
+    assert dependency_path?(graph, "lib/jido_browser.ex", "lib/jido_browser/fetch_rich.ex")
+    assert dependency_path?(graph, "lib/jido_browser/fetch_rich.ex", "lib/jido_browser.ex")
+  end
+
+  defp xref_graph do
+    path = Path.join(System.tmp_dir!(), "jido_browser_xref_#{System.unique_integer([:positive])}.dot")
+    Mix.Task.reenable("xref")
+    Xref.run(["graph", "--format", "dot", "--output", path])
+
+    try do
+      path
+      |> File.stream!()
+      |> Enum.reduce(%{}, fn line, graph ->
+        case Regex.run(~r/^\s*"([^"]+)" -> "([^"]+)"/, line) do
+          [_, source, sink] ->
+            graph
+            |> Map.put_new(sink, [])
+            |> Map.update(source, [sink], &[sink | &1])
+
+          nil ->
+            case Regex.run(~r/^\s*"([^"]+)"\s*$/, line) do
+              [_, node] -> Map.put_new(graph, node, [])
+              nil -> graph
+            end
+        end
+      end)
+    after
+      File.rm(path)
+    end
+  end
+
+  defp dependency_path?(graph, source, sink) do
+    dependency_path?(graph, [source], sink, MapSet.new())
+  end
+
+  defp assert_target_nodes_present(graph) do
+    for target <- @target_files do
+      assert Map.has_key?(graph, target), "expected xref graph to contain #{target}"
+    end
+  end
+
+  defp dependency_path?(_graph, [], _sink, _visited), do: false
+
+  defp dependency_path?(graph, [source | rest], sink, visited) do
+    cond do
+      source == sink ->
+        true
+
+      MapSet.member?(visited, source) ->
+        dependency_path?(graph, rest, sink, visited)
+
+      true ->
+        dependencies = Map.get(graph, source, [])
+        dependency_path?(graph, dependencies ++ rest, sink, MapSet.put(visited, source))
+    end
+  end
+end

--- a/test/jido_browser/warm_pool_runtime_test.exs
+++ b/test/jido_browser/warm_pool_runtime_test.exs
@@ -1,0 +1,63 @@
+defmodule Jido.Browser.WarmPoolRuntimeTest do
+  use ExUnit.Case, async: false
+
+  alias Jido.Browser.WarmPool.Manager
+  alias Jido.Browser.WarmPool.Runtime
+  alias Jido.Browser.WarmPool.TreeSupervisor
+
+  defmodule RuntimeProbe do
+    alias Jido.Browser.WarmPool.Runtime
+
+    @behaviour Runtime
+
+    @impl true
+    def start_worker(pool_state) do
+      test_pid = Keyword.fetch!(pool_state.worker_opts, :test_pid)
+      send(test_pid, {:runtime_context, Runtime.context(pool_state)})
+
+      {:ok, %{session_id: "runtime-context-probe", test_pid: test_pid}}
+    end
+
+    @impl true
+    def command(_worker_state, _payload, _timeout), do: {:error, :unsupported}
+
+    @impl true
+    def shutdown_worker(worker_state) do
+      send(worker_state.test_pid, :runtime_probe_stopped)
+      :ok
+    end
+  end
+
+  test "runtime context passes adapter data through without interpretation" do
+    callback = fn value -> {:ok, value} end
+    context = %{start: callback, metadata: {:adapter, "agent-browser"}}
+    name = "runtime-context-#{System.unique_integer([:positive])}"
+
+    assert {:ok, pool} =
+             TreeSupervisor.start_pool(
+               name: name,
+               size: 1,
+               adapter: __MODULE__,
+               worker_opts: [test_pid: self()],
+               pool_runtime_module: RuntimeProbe,
+               pool_runtime_context: context
+             )
+
+    on_exit(fn -> TreeSupervisor.stop_pool(pool) end)
+
+    assert_receive {:runtime_context, received_context}
+    assert received_context === context
+    assert Runtime.context(%{worker_opts: []}) == nil
+    assert callback.(123) == {:ok, 123}
+
+    assert {:ok, manager} = Manager.resolve(name)
+    manager_ref = Process.monitor(manager)
+    Process.exit(manager, :kill)
+    assert_receive {:DOWN, ^manager_ref, :process, ^manager, :killed}
+
+    assert_receive {:runtime_context, restarted_context}
+    assert restarted_context === context
+    assert {:ok, restarted_manager} = Manager.resolve(name)
+    refute restarted_manager == manager
+  end
+end


### PR DESCRIPTION
Closes #89.

## Commits

1. `2390007 refactor(pool): define adapter-neutral pool runtime boundary`
2. `1a7db82 refactor(adapters): remove pool-to-adapter dependency cycles`

## Old dependency graph

Before this change, `mix xref graph --format cycles` reported:

```text
3 cycles found. Showing them in decreasing size:

Cycle of length 13 (1 compile):

    lib/jido_browser/adapters/agent_browser.ex
    lib/jido_browser/adapters/web.ex
    lib/jido_browser/adapters/web/cli.ex
    lib/jido_browser/adapters/web/pool_runtime.ex
    lib/jido_browser/agent_browser/pool_runtime.ex
    lib/jido_browser/agent_browser/runtime.ex
    lib/jido_browser/agent_browser/session_server.ex
    lib/jido_browser/application.ex
    lib/jido_browser/deprecations.ex (compile)
    lib/jido_browser/installer.ex
    lib/jido_browser/warm_pool/manager.ex
    lib/jido_browser/warm_pool/tree_supervisor.ex
    lib/jido_browser/web_fetch/backends/browsey.ex

Cycle of length 2:

    lib/jido_browser/adapters/lightpanda.ex
    lib/jido_browser/adapters/lightpanda/pool_runtime.ex

Cycle of length 2:

    lib/jido_browser.ex
    lib/jido_browser/fetch_rich.ex
```

The main direct edges were:

- `AgentBrowser.build_pool_start_opts/2 -> AgentBrowser.PoolRuntime`
- `AgentBrowser.PoolRuntime.start_worker/1 -> AgentBrowser.Runtime.session_runtime_metadata/2`
- `AgentBrowser.PoolRuntime -> AgentBrowser.SessionServer`
- `AgentBrowser.SessionServer -> AgentBrowser.Runtime`
- `AgentBrowser.Runtime.find_binary/0 -> Installer.agent_browser_package_path/0`
- `Installer.configured_adapter_binary/0 -> Adapters.AgentBrowser`
- compile-time adapter references in `Deprecations` also joined the large cycle
- `Lightpanda.build_pool_start_opts/1 -> Lightpanda.PoolRuntime`
- `Lightpanda.PoolRuntime.start_worker/1 -> Lightpanda.start_connection/1`
- `Lightpanda.PoolRuntime.shutdown_worker/1 -> Lightpanda.stop_connection/1`

## New dependency graph

The pool manager now passes one opaque `runtime_context` value to the selected pool runtime. Adapters put only the callbacks and metadata that their pool runtime needs in this value. The pool runtime consumes the value and does not call back into its adapter module.

AgentBrowser protocol helpers and installer path helpers now have neutral modules. Existing public functions delegate to them. Installer and deprecation adapter selection uses fixed, existing module atoms without compile-time adapter edges. No dynamic module dispatch or runtime atom creation was added.

After this change, `mix xref graph --format cycles` reports:

```text
1 cycles found. Showing them in decreasing size:

Cycle of length 2:

    lib/jido_browser.ex
    lib/jido_browser/fetch_rich.ex
```

The remaining Browser/FetchRich cycle is unchanged and belongs to #92.

## Preserved contracts

- Pool names, child specifications, one-for-all supervision order, and process registration
- Checkout and checkin behavior, including the 5,000 ms default checkout timeout
- Worker ownership, start, health check, shutdown, and replacement behavior
- Installer paths, adapter selection, configured versions, and install behavior
- Session defaults, public APIs, options, tagged tuples, errors, and telemetry
- AgentBrowser 0.35.1 daemon, socket, command, and cleanup behavior
- Lightpanda connection, page, session runtime, and cleanup behavior
- WebFetch and FetchRich source and behavior

## Backward-compatibility evidence

- Focused pool, adapter, installer, and dependency tests: 106 passed
- Supported CI tests on Elixir 1.20 and OTP 29: 394 passed, 26 excluded
- Coverage: 68.7% (required floor: 53.0%)
- AgentBrowser 0.35.1 smoke test: 1 passed
- `mix quality`: passed
- Credo strict: no issues
- Dialyzer: 0 errors
- Doctor: 99.7% documentation, 100% module documentation, 100% specifications
- Format, compile warnings, docs, Hex audit, unused dependency check, and package dry run: passed
- Direction tests fail if an AgentBrowser or Lightpanda pool-to-adapter path returns
- Characterization tests cover pool context restart behavior, default pool registration and checkout, installer adapter selection, and adapter-specific cleanup

`CHANGELOG.md` is unchanged.



