### PR TITLE
refactor(fetch_rich): remove the public facade cycle

### DIFF
--- a/lib/jido_browser.ex
+++ b/lib/jido_browser.ex
@@ -11,15 +11,14 @@ defmodule Jido.Browser do
   alias Jido.Browser.FetchRich
   alias Jido.Browser.PoolAdapter
   alias Jido.Browser.Session
+  alias Jido.Browser.SessionOperations
   alias Jido.Browser.WarmPool.Manager
-  alias Jido.Browser.WarmPool.Names
   alias Jido.Browser.WarmPool.TreeSupervisor
   alias Jido.Browser.WebFetch
 
   @default_adapter Jido.Browser.Adapters.AgentBrowser
   @default_timeout 30_000
   @supported_screenshot_formats [:png]
-  @supported_extract_formats [:markdown, :html, :text]
   @supported_web_fetch_formats [:markdown, :html, :text]
 
   @doc """
@@ -54,42 +53,18 @@ defmodule Jido.Browser do
 
   @doc "Starts a browser session using the configured adapter or an explicit adapter override."
   @spec start_session(keyword()) :: {:ok, Session.t()} | {:error, term()}
-  def start_session(opts \\ []) do
-    with {:ok, adapter} <- resolve_session_adapter(opts),
-         :ok <- Deprecations.warn(adapter),
-         :ok <- validate_pool_capability(adapter, opts) do
-      case adapter.start_session(opts) do
-        {:ok, %Session{} = session} ->
-          {:ok, session}
-
-        %Session{} = session ->
-          {:ok, session}
-
-        {:error, _reason} = error ->
-          error
-
-        other ->
-          {:error, Error.adapter_error("Adapter returned invalid session result", %{adapter: adapter, result: other})}
-      end
-    end
-  end
+  def start_session(opts \\ []), do: SessionOperations.start_session(opts)
 
   @doc "Ends an active browser session."
   @spec end_session(Session.t()) :: :ok | {:error, term()}
-  def end_session(%Session{} = session), do: session.adapter.end_session(session)
+  def end_session(%Session{} = session), do: SessionOperations.end_session(session)
 
   @doc "Navigates the current session to a URL."
   @spec navigate(Session.t(), String.t(), keyword()) ::
           {:ok, Session.t(), map()} | {:error, term()}
   def navigate(session, url, opts \\ [])
 
-  def navigate(%Session{}, url, _opts) when url in [nil, ""] do
-    {:error, Error.invalid_error("URL cannot be nil or empty", %{url: url})}
-  end
-
-  def navigate(%Session{} = session, url, opts) do
-    session.adapter.navigate(session, url, normalize_timeout(opts))
-  end
+  def navigate(%Session{} = session, url, opts), do: SessionOperations.navigate(session, url, opts)
 
   @doc "Clicks an element identified by a selector or agent-browser ref."
   @spec click(Session.t(), String.t(), keyword()) ::
@@ -136,25 +111,7 @@ defmodule Jido.Browser do
   @doc "Extracts page content as markdown, HTML, or text."
   @spec extract_content(Session.t(), keyword()) ::
           {:ok, Session.t(), map()} | {:error, term()}
-  def extract_content(%Session{} = session, opts \\ []) do
-    format = opts[:format] || :markdown
-
-    if format in @supported_extract_formats do
-      opts =
-        opts
-        |> Keyword.put_new(:format, :markdown)
-        |> Keyword.put_new(:selector, "body")
-        |> normalize_timeout()
-
-      session.adapter.extract_content(session, opts)
-    else
-      {:error,
-       Error.invalid_error("Unsupported extract format: #{inspect(format)}", %{
-         format: format,
-         supported: @supported_extract_formats
-       })}
-    end
-  end
+  def extract_content(%Session{} = session, opts \\ []), do: SessionOperations.extract_content(session, opts)
 
   @doc """
   Fetches a URL over HTTP(S) without starting a browser session.
@@ -519,27 +476,7 @@ defmodule Jido.Browser do
 
   @doc "Returns an agent-oriented page snapshot with ref metadata when supported."
   @spec snapshot(Session.t(), keyword()) :: {:ok, Session.t(), map()} | {:error, term()}
-  def snapshot(%Session{} = session, opts \\ []) do
-    command_or_fallback(session, :snapshot, opts, fn ->
-      selector = opts[:selector] || "body"
-      max_content_length = opts[:max_content_length] || 50_000
-
-      script = """
-      (function snapshot(selector, maxContentLength) {
-        const root = document.querySelector(selector) || document.body;
-        return {
-          url: window.location.href,
-          title: document.title,
-          origin: window.location.href,
-          snapshot: root.innerText.substring(0, maxContentLength),
-          refs: {}
-        };
-      })(#{Jason.encode!(selector)}, #{max_content_length})
-      """
-
-      evaluate(session, script, opts)
-    end)
-  end
+  def snapshot(%Session{} = session, opts \\ []), do: SessionOperations.snapshot(session, opts)
 
   @doc "Persists browser session state to disk."
   @spec save_state(Session.t(), String.t(), keyword()) :: {:ok, Session.t(), map()} | {:error, term()}
@@ -774,66 +711,6 @@ defmodule Jido.Browser do
 
   defp configured_adapter do
     Application.get_env(:jido_browser, :adapter, @default_adapter)
-  end
-
-  defp adapter_for_pool(pool) do
-    case Names.resolve_manager(pool) do
-      {:ok, pid} ->
-        case GenServer.call(pid, :adapter) do
-          adapter when is_atom(adapter) ->
-            {:ok, adapter}
-
-          other ->
-            {:error, Error.adapter_error("Warm pool adapter could not be resolved", %{pool: pool, adapter: other})}
-        end
-
-      {:error, :pool_not_found} ->
-        {:error, Error.adapter_error("No warm pool available", %{pool: pool})}
-    end
-  catch
-    :exit, reason ->
-      {:error, Error.adapter_error("Failed to resolve warm pool adapter", %{pool: pool, reason: reason})}
-  end
-
-  defp resolve_session_adapter(opts) do
-    case opts[:pool] do
-      nil ->
-        {:ok, opts[:adapter] || configured_adapter()}
-
-      pool ->
-        maybe_resolve_pool_adapter(pool, opts[:adapter])
-    end
-  end
-
-  defp maybe_resolve_pool_adapter(pool, nil), do: adapter_for_pool(pool)
-
-  defp maybe_resolve_pool_adapter(pool, explicit_adapter) do
-    case adapter_for_pool(pool) do
-      {:ok, pool_adapter} when pool_adapter != explicit_adapter ->
-        {:error,
-         Error.invalid_error(
-           "Pool #{inspect(pool)} belongs to adapter #{inspect(pool_adapter)}, not #{inspect(explicit_adapter)}",
-           %{pool: pool, pool_adapter: pool_adapter, adapter: explicit_adapter}
-         )}
-
-      {:ok, _pool_adapter} ->
-        {:ok, explicit_adapter}
-
-      {:error, _reason} ->
-        {:ok, explicit_adapter}
-    end
-  end
-
-  defp validate_pool_capability(adapter, opts) do
-    if opts[:pool] && not PoolAdapter.supports_pools?(adapter) do
-      {:error,
-       Error.invalid_error(
-         "Adapter #{inspect(adapter)} does not support pooled sessions",
-         %{adapter: adapter}
-       )}
-    else
-      :ok
-    end
   end
 
   defp normalize_timeout(opts), do: Keyword.put_new(opts, :timeout, @default_timeout)

--- a/lib/jido_browser/fetch_rich.ex
+++ b/lib/jido_browser/fetch_rich.ex
@@ -7,6 +7,11 @@ defmodule Jido.Browser.FetchRich do
   """
 
   alias Jido.Browser.Error
+  alias Jido.Browser.SessionOperations
+  alias Jido.Browser.WebFetch
+
+  @default_timeout 30_000
+  @supported_web_fetch_formats [:markdown, :html, :text]
 
   @http_option_keys [
     :allow_private_network,
@@ -69,7 +74,7 @@ defmodule Jido.Browser.FetchRich do
     web_opts = opts |> Keyword.take(@http_option_keys) |> put_backend(backend)
     retrieval_path = http_retrieval_path(backend, web_opts)
 
-    case Jido.Browser.web_fetch(url, web_opts) do
+    case web_fetch(url, web_opts) do
       {:ok, result} -> handle_http_success(result, retrieval_path, url, opts, rest)
       {:error, reason} -> handle_http_error(reason, last_result, url, opts, rest)
     end
@@ -121,10 +126,10 @@ defmodule Jido.Browser.FetchRich do
   end
 
   defp fetch_browser(url, opts, fallback_reason) do
-    case Jido.Browser.start_session(browser_start_opts(opts)) do
+    case SessionOperations.start_session(browser_start_opts(opts)) do
       {:ok, session} ->
         try do
-          with {:ok, session, nav_result} <- Jido.Browser.navigate(session, url, timeout: opts[:timeout]),
+          with {:ok, session, nav_result} <- SessionOperations.navigate(session, url, timeout: opts[:timeout]),
                {:ok, result} <- browser_result(session, nav_result, url, opts, fallback_reason) do
             {:ok, result}
           else
@@ -137,7 +142,7 @@ defmodule Jido.Browser.FetchRich do
                })}
           end
         after
-          _ = Jido.Browser.end_session(session)
+          _ = SessionOperations.end_session(session)
         end
 
       {:error, reason} ->
@@ -172,7 +177,7 @@ defmodule Jido.Browser.FetchRich do
       |> Keyword.put_new(:selector, "body")
       |> Keyword.put_new(:max_content_length, max_content_length(opts))
 
-    case Jido.Browser.snapshot(session, snapshot_opts) do
+    case SessionOperations.snapshot(session, snapshot_opts) do
       {:ok, _session, snapshot} when is_map(snapshot) ->
         content = snapshot_content(snapshot)
 
@@ -200,7 +205,7 @@ defmodule Jido.Browser.FetchRich do
       |> Keyword.put_new(:format, :markdown)
       |> Keyword.put_new(:selector, "body")
 
-    with {:ok, _session, result} <- Jido.Browser.extract_content(session, extract_opts) do
+    with {:ok, _session, result} <- SessionOperations.extract_content(session, extract_opts) do
       {:ok,
        %{
          content: result_value(result, :content) || "",
@@ -262,6 +267,24 @@ defmodule Jido.Browser.FetchRich do
 
   defp put_backend(opts, :default), do: Keyword.delete(opts, :backend)
   defp put_backend(opts, backend), do: Keyword.put(opts, :backend, backend)
+
+  defp web_fetch(url, _opts) when url in [nil, ""] do
+    {:error, Error.invalid_error("URL cannot be nil or empty", %{url: url})}
+  end
+
+  defp web_fetch(url, opts) do
+    format = opts[:format] || :markdown
+
+    if format in @supported_web_fetch_formats do
+      WebFetch.fetch(url, Keyword.put_new(opts, :timeout, @default_timeout))
+    else
+      {:error,
+       Error.invalid_error("Unsupported web fetch format: #{inspect(format)}", %{
+         format: format,
+         supported: @supported_web_fetch_formats
+       })}
+    end
+  end
 
   defp http_retrieval_path(:browsey, _opts), do: :browsey
   defp http_retrieval_path(Jido.Browser.WebFetch.Backends.Browsey, _opts), do: :browsey

--- a/lib/jido_browser/session_operations.ex
+++ b/lib/jido_browser/session_operations.ex
@@ -1,0 +1,197 @@
+defmodule Jido.Browser.SessionOperations do
+  @moduledoc false
+
+  alias Jido.Browser.Deprecations
+  alias Jido.Browser.Error
+  alias Jido.Browser.PoolAdapter
+  alias Jido.Browser.Session
+  alias Jido.Browser.WarmPool.Names
+
+  @default_adapter Jido.Browser.Adapters.AgentBrowser
+  @default_timeout 30_000
+  @supported_extract_formats [:markdown, :html, :text]
+
+  @doc false
+  @spec start_session(keyword()) :: {:ok, Session.t()} | {:error, term()}
+  def start_session(opts) do
+    with {:ok, adapter} <- resolve_session_adapter(opts),
+         :ok <- Deprecations.warn(adapter),
+         :ok <- validate_pool_capability(adapter, opts) do
+      case adapter.start_session(opts) do
+        {:ok, %Session{} = session} ->
+          {:ok, session}
+
+        %Session{} = session ->
+          {:ok, session}
+
+        {:error, _reason} = error ->
+          error
+
+        other ->
+          {:error, Error.adapter_error("Adapter returned invalid session result", %{adapter: adapter, result: other})}
+      end
+    end
+  end
+
+  @doc false
+  @spec end_session(Session.t()) :: :ok | {:error, term()}
+  def end_session(%Session{} = session), do: session.adapter.end_session(session)
+
+  @doc false
+  @spec navigate(Session.t(), String.t(), keyword()) ::
+          {:ok, Session.t(), map()} | {:error, term()}
+  def navigate(%Session{}, url, _opts) when url in [nil, ""] do
+    {:error, Error.invalid_error("URL cannot be nil or empty", %{url: url})}
+  end
+
+  def navigate(%Session{} = session, url, opts) do
+    session.adapter.navigate(session, url, normalize_timeout(opts))
+  end
+
+  @doc false
+  @spec extract_content(Session.t(), keyword()) ::
+          {:ok, Session.t(), map()} | {:error, term()}
+  def extract_content(%Session{} = session, opts) do
+    format = opts[:format] || :markdown
+
+    if format in @supported_extract_formats do
+      opts =
+        opts
+        |> Keyword.put_new(:format, :markdown)
+        |> Keyword.put_new(:selector, "body")
+        |> normalize_timeout()
+
+      session.adapter.extract_content(session, opts)
+    else
+      {:error,
+       Error.invalid_error("Unsupported extract format: #{inspect(format)}", %{
+         format: format,
+         supported: @supported_extract_formats
+       })}
+    end
+  end
+
+  @doc false
+  @spec snapshot(Session.t(), keyword()) :: {:ok, Session.t(), map()} | {:error, term()}
+  def snapshot(%Session{} = session, opts) do
+    command_or_fallback(session, :snapshot, opts, fn ->
+      selector = opts[:selector] || "body"
+      max_content_length = opts[:max_content_length] || 50_000
+
+      script = """
+      (function snapshot(selector, maxContentLength) {
+        const root = document.querySelector(selector) || document.body;
+        return {
+          url: window.location.href,
+          title: document.title,
+          origin: window.location.href,
+          snapshot: root.innerText.substring(0, maxContentLength),
+          refs: {}
+        };
+      })(#{Jason.encode!(selector)}, #{max_content_length})
+      """
+
+      evaluate(session, script, opts)
+    end)
+  end
+
+  defp evaluate(%Session{adapter: adapter} = session, script, opts) do
+    if function_exported?(adapter, :evaluate, 3) do
+      adapter.evaluate(session, script, normalize_timeout(opts))
+    else
+      {:error,
+       Error.invalid_error(
+         "Adapter #{inspect(adapter)} does not support JavaScript evaluation",
+         %{adapter: adapter}
+       )}
+    end
+  end
+
+  defp command_or_fallback(%Session{} = session, action, opts, fallback_fun) do
+    if command_supported?(session) do
+      command(session, action, opts)
+    else
+      fallback_fun.()
+    end
+  end
+
+  defp command(%Session{adapter: adapter} = session, action, opts) do
+    if function_exported?(adapter, :command, 3) do
+      adapter.command(session, action, normalize_timeout(opts))
+    else
+      {:error,
+       Error.invalid_error(
+         "Adapter #{inspect(adapter)} does not support #{action}",
+         %{adapter: adapter, action: action}
+       )}
+    end
+  end
+
+  defp command_supported?(%Session{adapter: adapter}), do: function_exported?(adapter, :command, 3)
+
+  defp configured_adapter do
+    Application.get_env(:jido_browser, :adapter, @default_adapter)
+  end
+
+  defp adapter_for_pool(pool) do
+    case Names.resolve_manager(pool) do
+      {:ok, pid} ->
+        case GenServer.call(pid, :adapter) do
+          adapter when is_atom(adapter) ->
+            {:ok, adapter}
+
+          other ->
+            {:error, Error.adapter_error("Warm pool adapter could not be resolved", %{pool: pool, adapter: other})}
+        end
+
+      {:error, :pool_not_found} ->
+        {:error, Error.adapter_error("No warm pool available", %{pool: pool})}
+    end
+  catch
+    :exit, reason ->
+      {:error, Error.adapter_error("Failed to resolve warm pool adapter", %{pool: pool, reason: reason})}
+  end
+
+  defp resolve_session_adapter(opts) do
+    case opts[:pool] do
+      nil ->
+        {:ok, opts[:adapter] || configured_adapter()}
+
+      pool ->
+        maybe_resolve_pool_adapter(pool, opts[:adapter])
+    end
+  end
+
+  defp maybe_resolve_pool_adapter(pool, nil), do: adapter_for_pool(pool)
+
+  defp maybe_resolve_pool_adapter(pool, explicit_adapter) do
+    case adapter_for_pool(pool) do
+      {:ok, pool_adapter} when pool_adapter != explicit_adapter ->
+        {:error,
+         Error.invalid_error(
+           "Pool #{inspect(pool)} belongs to adapter #{inspect(pool_adapter)}, not #{inspect(explicit_adapter)}",
+           %{pool: pool, pool_adapter: pool_adapter, adapter: explicit_adapter}
+         )}
+
+      {:ok, _pool_adapter} ->
+        {:ok, explicit_adapter}
+
+      {:error, _reason} ->
+        {:ok, explicit_adapter}
+    end
+  end
+
+  defp validate_pool_capability(adapter, opts) do
+    if opts[:pool] && not PoolAdapter.supports_pools?(adapter) do
+      {:error,
+       Error.invalid_error(
+         "Adapter #{inspect(adapter)} does not support pooled sessions",
+         %{adapter: adapter}
+       )}
+    else
+      :ok
+    end
+  end
+
+  defp normalize_timeout(opts), do: Keyword.put_new(opts, :timeout, @default_timeout)
+end

--- a/test/jido_browser/fetch_rich_test.exs
+++ b/test/jido_browser/fetch_rich_test.exs
@@ -2,6 +2,9 @@ defmodule Jido.Browser.FetchRichTest do
   use ExUnit.Case, async: false
   use Mimic
 
+  alias Jido.Browser.Adapters.AgentBrowser
+  alias Jido.Browser.Error
+  alias Jido.Browser.FetchRich
   alias Jido.Browser.Session
   alias Jido.Browser.WebFetch
 
@@ -23,6 +26,8 @@ defmodule Jido.Browser.FetchRichTest do
 
   setup_all do
     Mimic.copy(Req)
+    Mimic.copy(AgentBrowser)
+    Mimic.copy(WebFetch)
     :ok
   end
 
@@ -66,7 +71,7 @@ defmodule Jido.Browser.FetchRichTest do
     assert result.content =~ "Browsey body"
   end
 
-  test "falls back to a browser session on blocked HTTP status when enabled" do
+  test "falls back to a browser session on blocked HTTP status when a pool option is present" do
     session = test_session()
 
     expect(Req, :run, fn opts ->
@@ -75,23 +80,29 @@ defmodule Jido.Browser.FetchRichTest do
       {request, response}
     end)
 
-    expect(Jido.Browser, :start_session, fn opts ->
-      assert opts[:pool] == :warm
+    expect(AgentBrowser, :start_session, fn opts ->
+      assert Keyword.has_key?(opts, :pool)
+      assert opts[:pool] == nil
       {:ok, session}
     end)
 
-    expect(Jido.Browser, :navigate, fn ^session, "https://example.com/protected", opts ->
+    expect(AgentBrowser, :navigate, fn ^session, "https://example.com/protected", opts ->
       assert opts[:timeout] == 30_000
       {:ok, session, %{url: "https://example.com/protected"}}
     end)
 
-    expect(Jido.Browser, :snapshot, fn ^session, _opts ->
+    expect(AgentBrowser, :command, fn ^session, :snapshot, _opts ->
       {:ok, session, %{url: "https://example.com/protected", title: "Protected", snapshot: "Rendered body"}}
     end)
 
-    expect(Jido.Browser, :end_session, fn ^session -> :ok end)
+    expect(AgentBrowser, :end_session, fn ^session -> :ok end)
 
-    assert {:ok, result} = Jido.Browser.fetch_rich("https://example.com/protected", pool: :warm)
+    assert {:ok, result} =
+             Jido.Browser.fetch_rich("https://example.com/protected",
+               adapter: AgentBrowser,
+               pool: nil
+             )
+
     assert result.retrieval_path == :browser
     assert result.fallback_reason == {:http_status, 403}
     assert result.content == "Rendered body"
@@ -113,26 +124,489 @@ defmodule Jido.Browser.FetchRichTest do
       {request, response}
     end)
 
-    expect(Jido.Browser, :start_session, fn opts ->
+    expect(AgentBrowser, :start_session, fn opts ->
       assert opts[:browser_fallback] == nil
       {:ok, session}
     end)
 
-    expect(Jido.Browser, :navigate, fn ^session, "https://example.com/js", _opts ->
+    expect(AgentBrowser, :navigate, fn ^session, "https://example.com/js", _opts ->
       {:ok, session, %{url: "https://example.com/js"}}
     end)
 
-    expect(Jido.Browser, :snapshot, fn ^session, _opts ->
+    expect(AgentBrowser, :command, fn ^session, :snapshot, _opts ->
       {:ok, session, %{url: "https://example.com/js", title: "JS Page", snapshot: "Rendered JS content"}}
     end)
 
-    expect(Jido.Browser, :end_session, fn ^session -> :ok end)
+    expect(AgentBrowser, :end_session, fn ^session -> :ok end)
 
     assert {:ok, result} = Jido.Browser.fetch_rich("https://example.com/js", browser_fallback: true)
     assert result.retrieval_path == :browser
     assert result.fallback_reason == :blocked_content
     assert result.content == "Rendered JS content"
   end
+
+  test "forwards only HTTP options and returns successful HTTP metadata without starting a browser" do
+    result = http_result("HTTP body")
+
+    expect(WebFetch, :fetch, fn "https://example.com/http", opts ->
+      assert opts ==
+               [
+                 backend: :browsey,
+                 citations: true,
+                 format: :text,
+                 max_response_bytes: 4_096,
+                 selector: "main",
+                 timeout: 1_234
+               ]
+
+      {:ok, result}
+    end)
+
+    reject(AgentBrowser, :start_session, 1)
+
+    assert {:ok, tagged_result} =
+             FetchRich.fetch(
+               "https://example.com/http",
+               adapter: AgentBrowser,
+               backend: :browsey,
+               browser_fallback: true,
+               citations: true,
+               format: :text,
+               max_response_bytes: 4_096,
+               selector: "main",
+               timeout: 1_234
+             )
+
+    assert tagged_result ==
+             result
+             |> Map.put(:retrieval_path, :browsey)
+             |> Map.put(:fallback_reason, nil)
+             |> Map.put(:blocked?, false)
+  end
+
+  test "does not start a browser for HTTP errors outside the fallback contract" do
+    error = Error.adapter_error("HTTP request failed", %{status: 500, response: "failure"})
+
+    expect(WebFetch, :fetch, fn "https://example.com/failure", [timeout: 30_000] ->
+      {:error, error}
+    end)
+
+    reject(AgentBrowser, :start_session, 1)
+
+    assert FetchRich.fetch(
+             "https://example.com/failure",
+             browser_fallback: true,
+             timeout: 30_000
+           ) == {:error, error}
+  end
+
+  test "does not start a browser when browser_fallback is truthy but not true" do
+    error = Error.adapter_error("HTTP request failed", %{status: 403})
+
+    expect(WebFetch, :fetch, fn "https://example.com/protected", [timeout: 30_000] ->
+      {:error, error}
+    end)
+
+    reject(AgentBrowser, :start_session, 1)
+
+    assert FetchRich.fetch(
+             "https://example.com/protected",
+             browser_fallback: :enabled,
+             timeout: 30_000
+           ) == {:error, error}
+  end
+
+  test "tries HTTP backends in order before browser fallback" do
+    first_error = Error.adapter_error("HTTP request failed", %{status: 403})
+    result = http_result("Second HTTP backend")
+    test_pid = self()
+
+    expect(WebFetch, :fetch, 2, fn "https://example.com/http-chain", opts ->
+      send(test_pid, {:http_backend, opts[:backend]})
+
+      case opts[:backend] do
+        :first -> {:error, first_error}
+        :second -> {:ok, result}
+      end
+    end)
+
+    reject(AgentBrowser, :start_session, 1)
+
+    assert {:ok, tagged_result} =
+             FetchRich.fetch(
+               "https://example.com/http-chain",
+               browser_fallback: true,
+               http_backends: [:first, :second],
+               timeout: 700
+             )
+
+    assert_receive {:http_backend, :first}
+    assert_receive {:http_backend, :second}
+    assert tagged_result.retrieval_path == :web_fetch
+    assert tagged_result.content == "Second HTTP backend"
+  end
+
+  test "preserves direct FetchRich timeout defaults across HTTP and browser calls" do
+    session = test_session()
+    http_error = Error.adapter_error("HTTP request failed", %{status: 403})
+
+    expect(WebFetch, :fetch, fn "https://example.com/default-timeout", opts ->
+      assert opts == [timeout: 30_000]
+      {:error, http_error}
+    end)
+
+    expect(AgentBrowser, :start_session, fn opts ->
+      assert opts == [adapter: AgentBrowser]
+      {:ok, session}
+    end)
+
+    expect(AgentBrowser, :navigate, fn ^session, "https://example.com/default-timeout", opts ->
+      assert opts == [timeout: nil]
+      {:ok, session, %{url: "https://example.com/default-timeout"}}
+    end)
+
+    expect(AgentBrowser, :command, fn ^session, :snapshot, opts ->
+      assert opts[:selector] == "body"
+      assert opts[:max_content_length] == 50_000
+      assert opts[:timeout] == 30_000
+      {:ok, session, %{snapshot: "Rendered with defaults"}}
+    end)
+
+    expect(AgentBrowser, :end_session, fn ^session -> :ok end)
+
+    assert {:ok, result} =
+             FetchRich.fetch(
+               "https://example.com/default-timeout",
+               adapter: AgentBrowser,
+               browser_fallback: true
+             )
+
+    assert result.content == "Rendered with defaults"
+  end
+
+  test "preserves the direct FetchRich error for unsupported HTTP formats" do
+    reject(WebFetch, :fetch, 2)
+    reject(AgentBrowser, :start_session, 1)
+
+    assert {:error, %Error.InvalidError{} = error} =
+             FetchRich.fetch("https://example.com/document", format: :pdf)
+
+    assert error.message == "Unsupported web fetch format: :pdf"
+    assert error.details == %{format: :pdf, supported: [:markdown, :html, :text]}
+  end
+
+  test "preserves empty URL validation for direct FetchRich and public Browser option forms" do
+    expected_error = Error.invalid_error("URL cannot be nil or empty", %{url: ""})
+    direct_fetch = &FetchRich.fetch/2
+
+    for opts <- [[], [format: :html], [format: :pdf]] do
+      assert direct_fetch.("", opts) == {:error, expected_error}
+      assert Jido.Browser.fetch_rich("", opts) == {:error, expected_error}
+    end
+
+    assert_raise FunctionClauseError, ~r/Jido\.Browser\.FetchRich\.fetch\/2/, fn ->
+      invoke(direct_fetch, "", %{})
+    end
+
+    assert Jido.Browser.fetch_rich("", %{}) == {:error, expected_error}
+  end
+
+  test "preserves adjacent whitespace and invalid URI validation" do
+    whitespace_error = Error.invalid_error("URL cannot be empty", %{error_code: :invalid_input})
+
+    invalid_uri_error =
+      Error.invalid_error("Web fetch only supports http and https URLs", %{
+        error_code: :invalid_input,
+        scheme: nil
+      })
+
+    for entrypoint <- [&FetchRich.fetch/2, &Jido.Browser.fetch_rich/2] do
+      assert entrypoint.("   ", []) == {:error, whitespace_error}
+      assert entrypoint.("not a url", []) == {:error, invalid_uri_error}
+    end
+  end
+
+  test "preserves adjacent non-binary and non-list option behavior" do
+    direct_fetch = &FetchRich.fetch/2
+    browser_fetch = &Jido.Browser.fetch_rich/2
+
+    for url <- [nil, 123] do
+      assert_raise FunctionClauseError, ~r/Jido\.Browser\.FetchRich\.fetch\/2/, fn ->
+        direct_fetch.(url, [])
+      end
+    end
+
+    nil_error = Error.invalid_error("URL cannot be nil or empty", %{url: nil})
+    assert Jido.Browser.fetch_rich(nil, []) == {:error, nil_error}
+
+    browser_function_clause = ~r/Jido\.Browser(?:\.Mimic\.Original\.Module)?\.fetch_rich\/2/
+
+    assert_raise FunctionClauseError, browser_function_clause, fn ->
+      invoke(browser_fetch, 123, [])
+    end
+
+    assert_raise FunctionClauseError, ~r/Jido\.Browser\.FetchRich\.fetch\/2/, fn ->
+      invoke(direct_fetch, "https://example.com", %{})
+    end
+
+    assert_raise FunctionClauseError, ~r/Keyword\.put_new\/3/, fn ->
+      invoke(browser_fetch, "https://example.com", %{})
+    end
+  end
+
+  test "uses the browser after a fallback HTTP error and preserves options, metadata, and cleanup order" do
+    session = test_session()
+    http_error = Error.adapter_error("HTTP request failed", %{status: 403})
+    test_pid = self()
+
+    expect(WebFetch, :fetch, fn "https://example.com/protected", opts ->
+      send(test_pid, {:trace, :http})
+      assert opts == [citations: true, format: :markdown, max_content_tokens: 3, selector: "article", timeout: 9_876]
+      {:error, http_error}
+    end)
+
+    expect(AgentBrowser, :start_session, fn opts ->
+      send(test_pid, {:trace, :start_session})
+
+      assert opts ==
+               [
+                 adapter: AgentBrowser,
+                 checkout_timeout: 2_000,
+                 headless: false,
+                 timeout: 9_876
+               ]
+
+      {:ok, session}
+    end)
+
+    expect(AgentBrowser, :navigate, fn ^session, "https://example.com/protected", opts ->
+      send(test_pid, {:trace, :navigate})
+      assert opts == [timeout: 9_876]
+      {:ok, session, %{url: "https://example.com/rendered"}}
+    end)
+
+    expect(AgentBrowser, :command, fn ^session, :snapshot, opts ->
+      send(test_pid, {:trace, :snapshot})
+      assert opts == [max_content_length: 12, selector: "article", timeout: 9_876]
+
+      {:ok, session,
+       %{
+         url: "https://example.com/rendered",
+         title: "Rendered title",
+         snapshot: "Rendered body that is longer than twelve characters"
+       }}
+    end)
+
+    expect(AgentBrowser, :end_session, fn ^session ->
+      send(test_pid, {:trace, :end_session})
+      :ok
+    end)
+
+    assert {:ok, result} =
+             FetchRich.fetch(
+               "https://example.com/protected",
+               adapter: AgentBrowser,
+               browser_fallback: true,
+               checkout_timeout: 2_000,
+               citations: true,
+               format: :markdown,
+               headless: false,
+               max_content_tokens: 3,
+               selector: "article",
+               timeout: 9_876
+             )
+
+    assert_receive {:trace, :http}
+    assert_receive {:trace, :start_session}
+    assert_receive {:trace, :navigate}
+    assert_receive {:trace, :snapshot}
+    assert_receive {:trace, :end_session}
+
+    assert result == %{
+             blocked?: false,
+             cached: false,
+             citations: %{enabled: true},
+             content: "Rendered bod",
+             content_type: "text/html",
+             document_type: :html,
+             estimated_tokens: 3,
+             fallback_reason: {:http_status, 403},
+             filtered: false,
+             final_url: "https://example.com/rendered",
+             focus_matches: 0,
+             format: :markdown,
+             original_estimated_tokens: 13,
+             passages: [
+               %{
+                 end_char: 12,
+                 index: 0,
+                 start_char: 0,
+                 text: "Rendered bod",
+                 title: "Rendered title",
+                 url: "https://example.com/rendered"
+               }
+             ],
+             retrieval_path: :browser,
+             retrieved_at: result.retrieved_at,
+             title: "Rendered title",
+             truncated: true,
+             url: "https://example.com/rendered"
+           }
+  end
+
+  test "uses extraction after a snapshot error and always ends the browser session" do
+    session = test_session()
+    http_error = Error.adapter_error("HTTP request failed", %{error_code: :url_not_accessible})
+    snapshot_error = Error.adapter_error("Snapshot failed", %{})
+
+    expect(WebFetch, :fetch, fn "https://example.com/extract", [format: :text, selector: "main", timeout: 500] ->
+      {:error, http_error}
+    end)
+
+    expect(AgentBrowser, :start_session, fn [adapter: AgentBrowser, timeout: 500] ->
+      {:ok, session}
+    end)
+
+    expect(AgentBrowser, :navigate, fn ^session, "https://example.com/extract", [timeout: 500] ->
+      {:ok, session, %{url: "https://example.com/final"}}
+    end)
+
+    expect(AgentBrowser, :command, fn ^session, :snapshot, opts ->
+      assert opts == [max_content_length: 50_000, selector: "main", timeout: 500]
+      {:error, snapshot_error}
+    end)
+
+    expect(AgentBrowser, :extract_content, fn ^session, opts ->
+      assert opts == [format: :text, selector: "main", timeout: 500]
+      {:ok, session, %{content: "Extracted text", format: :text, title: "Extracted title"}}
+    end)
+
+    expect(AgentBrowser, :end_session, fn ^session -> :ok end)
+
+    assert {:ok, result} =
+             FetchRich.fetch(
+               "https://example.com/extract",
+               adapter: AgentBrowser,
+               browser_fallback: true,
+               format: :text,
+               selector: "main",
+               timeout: 500
+             )
+
+    assert result.content == "Extracted text"
+    assert result.final_url == "https://example.com/final"
+    assert result.title == "Extracted title"
+    assert result.format == :text
+    assert result.fallback_reason == :url_not_accessible
+  end
+
+  test "wraps navigation errors and ends an already-started browser session" do
+    session = test_session()
+    http_error = Error.adapter_error("HTTP request failed", %{status: 429})
+    navigation_error = Error.navigation_error("https://example.com/rate-limited", :timeout)
+
+    expect(WebFetch, :fetch, fn "https://example.com/rate-limited", [timeout: 250] ->
+      {:error, http_error}
+    end)
+
+    expect(AgentBrowser, :start_session, fn [adapter: AgentBrowser, timeout: 250] ->
+      {:ok, session}
+    end)
+
+    expect(AgentBrowser, :navigate, fn ^session, "https://example.com/rate-limited", [timeout: 250] ->
+      {:error, navigation_error}
+    end)
+
+    expect(AgentBrowser, :end_session, fn ^session -> :ok end)
+
+    assert {:error, %Error.AdapterError{} = error} =
+             FetchRich.fetch(
+               "https://example.com/rate-limited",
+               adapter: AgentBrowser,
+               browser_fallback: true,
+               timeout: 250
+             )
+
+    assert error.message == "Browser fallback failed"
+
+    assert error.details == %{
+             fallback_reason: {:http_status, 429},
+             reason: navigation_error,
+             url: "https://example.com/rate-limited"
+           }
+  end
+
+  test "wraps browser start errors without attempting cleanup" do
+    http_error = Error.adapter_error("HTTP request failed", %{status: 401})
+    start_error = Error.adapter_error("Start failed", %{reason: :unavailable})
+
+    expect(WebFetch, :fetch, fn "https://example.com/login", [timeout: 100] ->
+      {:error, http_error}
+    end)
+
+    expect(AgentBrowser, :start_session, fn [adapter: AgentBrowser, timeout: 100] ->
+      {:error, start_error}
+    end)
+
+    reject(AgentBrowser, :end_session, 1)
+
+    assert {:error, %Error.AdapterError{} = error} =
+             FetchRich.fetch(
+               "https://example.com/login",
+               adapter: AgentBrowser,
+               browser_fallback: true,
+               timeout: 100
+             )
+
+    assert error.message == "Browser fallback failed to start"
+
+    assert error.details == %{
+             fallback_reason: {:http_status, 401},
+             reason: start_error,
+             url: "https://example.com/login"
+           }
+  end
+
+  test "returns blocked HTTP metadata when browser fallback is disabled" do
+    result = http_result("Please verify you are human")
+
+    expect(WebFetch, :fetch, fn "https://example.com/challenge", [timeout: 30_000] ->
+      {:ok, result}
+    end)
+
+    reject(AgentBrowser, :start_session, 1)
+
+    assert {:ok, tagged_result} = FetchRich.fetch("https://example.com/challenge", timeout: 30_000)
+
+    assert tagged_result ==
+             result
+             |> Map.put(:retrieval_path, :web_fetch)
+             |> Map.put(:fallback_reason, :blocked_content)
+             |> Map.put(:blocked?, true)
+  end
+
+  defp http_result(content) do
+    %{
+      cached: false,
+      citations: %{enabled: false},
+      content: content,
+      content_type: "text/html",
+      document_type: :html,
+      estimated_tokens: 3,
+      filtered: false,
+      final_url: "https://example.com/final",
+      focus_matches: 0,
+      format: :markdown,
+      original_estimated_tokens: 3,
+      passages: [],
+      retrieved_at: "2026-08-27T12:00:00Z",
+      title: "HTTP title",
+      truncated: false,
+      url: "https://example.com/final"
+    }
+  end
+
+  defp invoke(function, first, second), do: function.(first, second)
 
   defp test_session do
     Session.new!(%{

--- a/test/jido_browser/pool_dependency_direction_test.exs
+++ b/test/jido_browser/pool_dependency_direction_test.exs
@@ -35,9 +35,9 @@ defmodule Jido.Browser.PoolDependencyDirectionTest do
     refute dependency_path?(graph, @lightpanda_pool_runtime, @lightpanda_adapter)
   end
 
-  test "the Browser and FetchRich cycle stays assigned to issue 92", %{graph: graph} do
+  test "Browser and FetchRich keep one-way dependency direction", %{graph: graph} do
     assert dependency_path?(graph, "lib/jido_browser.ex", "lib/jido_browser/fetch_rich.ex")
-    assert dependency_path?(graph, "lib/jido_browser/fetch_rich.ex", "lib/jido_browser.ex")
+    refute dependency_path?(graph, "lib/jido_browser/fetch_rich.ex", "lib/jido_browser.ex")
   end
 
   defp xref_graph do


### PR DESCRIPTION
Closes #92

## Summary

Remove the `Jido.Browser` ↔ `Jido.Browser.FetchRich` dependency cycle without changing the public Browser or FetchRich contract.

Old direction:

```text
Jido.Browser -> Jido.Browser.FetchRich
Jido.Browser.FetchRich -> Jido.Browser
```

The reverse edge included `web_fetch/2`, `start_session/1`, `navigate/3`, `snapshot/2`, `extract_content/2`, and `end_session/1`.

New direction:

```text
Jido.Browser -> Jido.Browser.FetchRich
Jido.Browser -> Jido.Browser.SessionOperations
Jido.Browser.FetchRich -> Jido.Browser.SessionOperations
Jido.Browser.FetchRich -> Jido.Browser.WebFetch
```

`Jido.Browser.SessionOperations` is an undocumented internal boundary that contains only the session operations shared by the public facade and the FetchRich browser fallback. There is no callback module, `apply/3`, atom creation, or hidden global state.

## Preserved fallback and validation contract

- HTTP retrieval remains first.
- Configured HTTP backends retain their order.
- Browser fallback still occurs only when `browser_fallback: true` or a `:pool` key is present, and only for the existing blocked-content and fallback-error conditions.
- Browser start, navigation, snapshot, extraction fallback, and cleanup retain the same option filtering, timeout behavior, adapter calls, tagged tuples, errors, and metadata.
- An already-started browser session is still ended after success or error. A failed start does not attempt cleanup.
- Direct FetchRich and public Browser URL validation match base for empty binaries, whitespace, invalid URI text, non-binary input, supported and unsupported format options, and non-list options.
- Public exports, docs, types, and specs for `Jido.Browser` and `Jido.Browser.FetchRich` match base exactly.

## Commit

- `1ed50a0bd8dfd72553977e2944d4cc60d9a5cba2 refactor(fetch_rich): remove the public facade cycle`

This PR has one issue-defined commit.

## Evidence

Base: `b2db3b6aee8b24befd72309b595cbc81a55eecbf`

- `mix test test/jido_browser/fetch_rich_test.exs`: 18 passed
- `mix test test/jido_browser_test.exs`: 11 passed
- dependency-direction tests: 4 passed
- differential URL-validation harness: base and head match for all audited cases
- `mix test`: 408 passed, 26 integration tests excluded
- `mix coveralls`: 408 passed, 26 excluded, 69.4% coverage (floor: 53.0%)
- `mix compile --warnings-as-errors`: passed
- `mix format --check-formatted`: passed
- `mix credo --strict`: passed with no issues
- `mix dialyzer`: 0 errors, 0 skipped, 0 unnecessary skips
- `mix doctor --raise`: passed; 99.7% doc coverage and 100% spec coverage
- `mix docs -f html`: passed
- `mix hex.audit`: no retired or advisory packages
- `mix deps.unlock --check-unused`: passed
- `HEX_API_KEY=dry-run mix hex.publish --dry-run --yes`: passed
- AgentBrowser 0.35.1 required smoke: 1 passed
- `mix xref graph --format cycles`: `No cycles found`
- `CHANGELOG.md`: unchanged
- Diff against base does not repeat the pool-cycle production changes from #89.

## Residual risk

The main risk is accidental drift between the facade delegates and the internal boundaries. Direct call-trace tests cover HTTP success, fallback and non-fallback HTTP errors, HTTP backend order, browser success and errors, option forwarding, direct timeout defaults, URL validation, metadata, extraction fallback, and cleanup. The supported Elixir/OTP matrix and Linux AgentBrowser lane run in PR CI.
