### PR TITLE
ci(release): stage checked release commits for protected main

### DIFF
--- a/.github/scripts/validate-generated-release.sh
+++ b/.github/scripts/validate-generated-release.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+python3 - <<'PY'
+import os
+import re
+import subprocess
+import sys
+
+
+REPOSITORY_URL = "https://github.com/agentjido/jido_browser"
+VISIBLE_TYPES = {
+    "feat": "Features",
+    "fix": "Bug Fixes",
+    "perf": "Performance",
+    "refactor": "Refactoring",
+    "security": "Security",
+    "deprecate": "Deprecated",
+}
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+TAG_RE = re.compile(
+    r"^v[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z][0-9A-Za-z.-]*)?"
+    r"(?:\+[0-9A-Za-z][0-9A-Za-z.-]*)?$"
+)
+SUBJECT_RE = re.compile(
+    r"^(feat|fix|perf|refactor|security|deprecate)"
+    r"(?:\(([^)\r\n]+)\))?!?: (.+)$"
+)
+
+
+def fail(message):
+    print(f"Generated release validation failed: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def required_environment(name, pattern=None):
+    value = os.environ.get(name, "")
+    if not value or (pattern is not None and not pattern.fullmatch(value)):
+        fail(f"{name} is missing or invalid")
+    return value
+
+
+def git(*arguments, binary=False, strip=True):
+    result = subprocess.run(
+        ["git", *arguments],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=not binary,
+    )
+    if result.returncode != 0:
+        error = result.stderr if not binary else result.stderr.decode("utf-8", "replace")
+        fail(error.strip() or f"git {' '.join(arguments)} failed")
+    return result.stdout if binary or not strip else result.stdout.strip()
+
+
+parent = required_environment("RELEASE_PARENT_SHA", SHA_RE)
+release = required_environment("RELEASE_SHA", SHA_RE)
+tree = required_environment("RELEASE_TREE_SHA", SHA_RE)
+tag = required_environment("RELEASE_TAG", TAG_RE)
+old_changelog_sha = required_environment("RELEASE_CHANGELOG_BEFORE_SHA", SHA_RE)
+new_changelog_sha = required_environment("RELEASE_CHANGELOG_AFTER_SHA", SHA_RE)
+
+if git("rev-parse", "HEAD") != release:
+    fail("HEAD is not the recorded release commit")
+if git("rev-list", "--parents", "-n", "1", release).split() != [release, parent]:
+    fail("the release is not one commit from the recorded parent")
+if git("rev-parse", f"{release}^{{tree}}") != tree:
+    fail("the release tree does not match the recorded tree")
+if git("rev-parse", f"{parent}:CHANGELOG.md") != old_changelog_sha:
+    fail("the parent changelog does not match the recorded blob")
+if git("rev-parse", f"{release}:CHANGELOG.md") != new_changelog_sha:
+    fail("the release changelog does not match the recorded blob")
+if git("show", "-s", "--format=%s", release) != f"chore: release version {tag}":
+    fail("the release commit subject is not the expected GitOps subject")
+
+changed = git("diff", "--name-only", "-z", parent, release, binary=True)
+changed_paths = sorted(path.decode("utf-8") for path in changed.split(b"\0") if path)
+if changed_paths != ["CHANGELOG.md", "mix.exs"]:
+    fail(f"the release changed unexpected paths: {changed_paths}")
+
+previous_tag = git("describe", "--tags", "--abbrev=0", parent)
+if not TAG_RE.fullmatch(previous_tag):
+    fail("the parent has no valid previous release tag")
+previous_version = previous_tag.removeprefix("v")
+version = tag.removeprefix("v")
+
+old_mix = git("show", f"{parent}:mix.exs", strip=False)
+new_mix = git("show", f"{release}:mix.exs", strip=False)
+old_version_literal = f'@version "{previous_version}"'
+if old_mix.count(old_version_literal) != 1:
+    fail("the parent mix.exs does not have one previous version literal")
+expected_mix = old_mix.replace(old_version_literal, f'@version "{version}"')
+if new_mix != expected_mix:
+    fail("mix.exs changed by more than the exact version replacement")
+
+old_changelog = git("show", f"{parent}:CHANGELOG.md", strip=False)
+new_changelog = git("show", f"{release}:CHANGELOG.md", strip=False)
+old_unreleased = f"[Unreleased]: {REPOSITORY_URL}/compare/{previous_tag}...HEAD"
+new_unreleased = f"[Unreleased]: {REPOSITORY_URL}/compare/{tag}...HEAD"
+if old_changelog.splitlines().count(old_unreleased) != 1:
+    fail("the parent changelog does not have one expected Unreleased link")
+if new_changelog.splitlines().count(new_unreleased) != 1:
+    fail("the release changelog does not have one expected Unreleased link")
+
+release_date = git("show", "-s", "--format=%cs", release)
+release_heading = (
+    f"## [{tag}]({REPOSITORY_URL}/compare/{previous_tag}...{tag}) ({release_date})"
+)
+if new_changelog.splitlines().count(release_heading) != 1:
+    fail("the release changelog does not have one exact version heading")
+
+history_heading = f"## [{previous_tag}]"
+old_history_index = old_changelog.find(history_heading)
+new_history_index = new_changelog.find(history_heading)
+release_index = new_changelog.find(release_heading)
+marker_index = new_changelog.find("<!-- changelog -->")
+if min(old_history_index, new_history_index, release_index, marker_index) < 0:
+    fail("the changelog section markers are incomplete")
+if not marker_index < release_index < new_history_index:
+    fail("the generated release section is in the wrong location")
+if old_changelog[old_history_index:] != new_changelog[new_history_index:]:
+    fail("the generated release changed historical changelog content")
+
+release_section = new_changelog[release_index:new_history_index]
+subjects = git("log", "--format=%s", f"{previous_tag}..{parent}").splitlines()
+expected_entries = []
+expected_headers = set()
+for subject in subjects:
+    match = SUBJECT_RE.fullmatch(subject)
+    if not match:
+        continue
+    change_type, scope, description = match.groups()
+    expected_headers.add(VISIBLE_TYPES[change_type])
+    expected_entries.append(f"{scope}: {description}" if scope else description)
+
+if not expected_entries:
+    fail("the release range has no visible conventional changes")
+
+actual_entries = [
+    line.removeprefix("* ")
+    for line in release_section.splitlines()
+    if line.startswith("* ")
+]
+if len(actual_entries) != len(expected_entries):
+    fail("the release entry count does not match visible conventional commits")
+for expected in expected_entries:
+    matches = [entry for entry in actual_entries if entry.startswith(f"{expected} by ")]
+    if len(matches) != 1:
+        fail(f"the release section does not contain one generated entry for: {expected}")
+
+actual_headers = {
+    match.group(1)
+    for line in release_section.splitlines()
+    if (match := re.fullmatch(r"### ([^:]+):", line))
+}
+if actual_headers != expected_headers:
+    fail("the release section headings do not match the visible change types")
+
+print(f"Validated exact generated release output for {tag} from {previous_tag}.")
+PY

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,13 @@
 name: CI
 
 on:
+  workflow_dispatch:
+    inputs:
+      release_validation:
+        description: Trusted metadata from the checked release workflow
+        required: false
+        type: string
+        default: ""
   pull_request:
   merge_group:
   push:
@@ -18,11 +25,12 @@ permissions:
 jobs:
   ci:
     name: CI
-    uses: agentjido/github-actions/.github/workflows/jido-ci.yml@v5
-    secrets: inherit
+    uses: agentjido/github-actions/.github/workflows/jido-ci.yml@v5.2.1
     with:
       docs_command: mix docs -f html
       test_command: mix coveralls
+      release_validation: ${{ inputs.release_validation || '' }}
+      generated_release_command: .github/scripts/validate-generated-release.sh
 
   agent-browser-smoke:
     name: AgentBrowser smoke

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,16 @@ on:
         required: false
         type: string
         default: ""
+      staged_prepare:
+        description: "Validate the generated commit before protected-main promotion"
+        required: false
+        type: boolean
+        default: true
+      staging_branch_prefix:
+        description: "Owned checked-release branch prefix"
+        required: false
+        type: string
+        default: "release/gitops/"
 
 permissions:
   actions: write
@@ -48,7 +58,7 @@ permissions:
 jobs:
   release:
     name: Release
-    uses: agentjido/github-actions/.github/workflows/jido-release.yml@v5
+    uses: agentjido/github-actions/.github/workflows/jido-release.yml@v5.2.1
     with:
       operation: ${{ inputs.operation || 'auto' }}
       tag_name: ${{ inputs.tag_name || '' }}
@@ -57,5 +67,12 @@ jobs:
       skip_tests: ${{ inputs.skip_tests || false }}
       version_override: ${{ inputs.version_override || '' }}
       release_command: mix jido_browser.release --yes
+      staged_prepare: ${{ inputs.staged_prepare }}
+      validation_workflow: ci.yml
+      required_checks: '["AgentBrowser smoke","CI / Summary"]'
+      release_changed_files: '["CHANGELOG.md","mix.exs"]'
+      generated_release_command: .github/scripts/validate-generated-release.sh
+      staging_branch_prefix: ${{ inputs.staging_branch_prefix || 'release/gitops/' }}
+      validation_timeout_seconds: 2700
     secrets:
       HEX_API_KEY: ${{ secrets.HEX_API_KEY }}

--- a/test/jido_browser/generated_release_validator_test.exs
+++ b/test/jido_browser/generated_release_validator_test.exs
@@ -1,0 +1,160 @@
+defmodule Jido.Browser.GeneratedReleaseValidatorTest do
+  use ExUnit.Case, async: true
+
+  @repository_url "https://github.com/agentjido/jido_browser"
+  @release_date "2026-08-28"
+
+  test "accepts the exact generated release output" do
+    fixture = release_fixture()
+
+    assert {output, 0} = run_validator(fixture)
+    assert output =~ "Validated exact generated release output for v2.4.0 from v2.3.0."
+  end
+
+  test "rejects a manual changelog entry" do
+    fixture = release_fixture(entry: "fetch: manually written text (#1)")
+
+    assert {output, status} = run_validator(fixture)
+    assert status != 0
+    assert output =~ "does not contain one generated entry"
+  end
+
+  test "rejects an extra generated path" do
+    fixture = release_fixture(extra_path: true)
+
+    assert {output, status} = run_validator(fixture)
+    assert status != 0
+    assert output =~ "changed unexpected paths"
+  end
+
+  defp release_fixture(options \\ []) do
+    directory =
+      Path.join(
+        System.tmp_dir!(),
+        "jido_browser_generated_release_#{System.unique_integer([:positive])}"
+      )
+
+    on_exit(fn -> File.rm_rf(directory) end)
+    File.mkdir_p!(directory)
+
+    File.write!(Path.join(directory, "mix.exs"), mix_project("2.3.0"))
+    File.write!(Path.join(directory, "CHANGELOG.md"), parent_changelog())
+
+    git!(directory, ["init", "--initial-branch=main"])
+    git!(directory, ["config", "user.name", "Release Test"])
+    git!(directory, ["config", "user.email", "release-test@example.com"])
+    git!(directory, ["add", "CHANGELOG.md", "mix.exs"])
+    git!(directory, ["commit", "-m", "chore: release fixture"])
+    git!(directory, ["tag", "-a", "v2.3.0", "-m", "v2.3.0"])
+    git!(directory, ["commit", "--allow-empty", "-m", "refactor(fetch): split retrieval (#1)"])
+
+    parent = git!(directory, ["rev-parse", "HEAD"])
+    entry = Keyword.get(options, :entry, "fetch: split retrieval (#1)")
+
+    File.write!(Path.join(directory, "mix.exs"), mix_project("2.4.0"))
+    File.write!(Path.join(directory, "CHANGELOG.md"), release_changelog(entry))
+
+    if Keyword.get(options, :extra_path, false) do
+      File.write!(Path.join(directory, "unexpected.txt"), "unexpected\n")
+    end
+
+    git!(directory, ["add", "--all"])
+
+    git!(
+      directory,
+      ["commit", "-m", "chore: release version v2.4.0"],
+      env: [
+        {"GIT_AUTHOR_DATE", "#{@release_date}T12:00:00Z"},
+        {"GIT_COMMITTER_DATE", "#{@release_date}T12:00:00Z"}
+      ]
+    )
+
+    release = git!(directory, ["rev-parse", "HEAD"])
+
+    %{
+      directory: directory,
+      parent: parent,
+      release: release,
+      tree: git!(directory, ["rev-parse", "#{release}^{tree}"]),
+      old_changelog: git!(directory, ["rev-parse", "#{parent}:CHANGELOG.md"]),
+      new_changelog: git!(directory, ["rev-parse", "#{release}:CHANGELOG.md"])
+    }
+  end
+
+  defp run_validator(fixture) do
+    script = Path.expand(".github/scripts/validate-generated-release.sh", File.cwd!())
+
+    System.cmd(script, [],
+      cd: fixture.directory,
+      env: [
+        {"RELEASE_PARENT_SHA", fixture.parent},
+        {"RELEASE_SHA", fixture.release},
+        {"RELEASE_TREE_SHA", fixture.tree},
+        {"RELEASE_TAG", "v2.4.0"},
+        {"RELEASE_CHANGELOG_BEFORE_SHA", fixture.old_changelog},
+        {"RELEASE_CHANGELOG_AFTER_SHA", fixture.new_changelog}
+      ],
+      stderr_to_stdout: true
+    )
+  end
+
+  defp git!(directory, arguments, options \\ []) do
+    command_options = Keyword.merge([cd: directory, stderr_to_stdout: true], options)
+
+    case System.cmd("git", arguments, command_options) do
+      {output, 0} -> String.trim(output)
+      {output, status} -> raise "git failed with #{status}: #{output}"
+    end
+  end
+
+  defp mix_project(version) do
+    """
+    defmodule ReleaseFixture.MixProject do
+      @version "#{version}"
+      def project, do: [version: @version]
+    end
+    """
+  end
+
+  defp parent_changelog do
+    """
+    # Changelog
+
+    ## [Unreleased]
+
+    [Unreleased]: #{@repository_url}/compare/v2.3.0...HEAD
+
+    <!-- changelog -->
+
+    ## [v2.3.0](#{@repository_url}/compare/v2.2.0...v2.3.0) (2026-08-27)
+
+    ### Refactoring:
+
+    * previous release entry by Release Test
+    """
+  end
+
+  defp release_changelog(entry) do
+    """
+    # Changelog
+
+    ## [Unreleased]
+
+    [Unreleased]: #{@repository_url}/compare/v2.4.0...HEAD
+
+    <!-- changelog -->
+
+    ## [v2.4.0](#{@repository_url}/compare/v2.3.0...v2.4.0) (#{@release_date})
+
+    ### Refactoring:
+
+    * #{entry} by Release Test
+
+    ## [v2.3.0](#{@repository_url}/compare/v2.2.0...v2.3.0) (2026-08-27)
+
+    ### Refactoring:
+
+    * previous release entry by Release Test
+    """
+  end
+end


### PR DESCRIPTION
Closes #115

## Outcome

Adopt the exact shared `agentjido/github-actions@v5.2.1` checked-release flow for Jido Browser.

A normal manual prepare now:

1. Generates one local release commit and annotated tag.
2. Saves a private manifest and Git bundle.
3. Pushes only `release/gitops/<version>`.
4. Dispatches the exact CI workflow on that commit.
5. Requires `AgentBrowser smoke`, `CI / Summary`, and the complete validation run to succeed.
6. Atomically fast-forwards `main`, creates the existing tag object, and deletes the staging branch.
7. Dispatches publish once.

## Repository changes

- Pin CI and release callers to immutable shared tag `v5.2.1`.
- Add trusted `workflow_dispatch` metadata to CI.
- Remove inherited CI secrets. Checked validation has only read access.
- Enable checked prepare by default while keeping direct tag-push publish compatibility.
- Bind the allowed release changes to `CHANGELOG.md` and `mix.exs`.
- Add a package-specific validator for the exact GitOps commit subject, version change, changelog links, history, headings, and visible entries.
- Add fixtures that accept exact generated output and reject a manual changelog or extra generated path.

## Verification

- `mix compile --warnings-as-errors`
- `mix format --check-formatted`
- Full unit suite: 411 passed, 26 integration tests excluded
- `mix q`: passed, including Credo, Dialyzer, Doctor, and formatting
- Actionlint 1.7.7: passed
- Workflow YAML parsing: passed
- Validator fixtures: 3 passed
- Real local GitOps 2.4.0 generation: passed
- Real generated commit changed only `CHANGELOG.md` and `mix.exs`
- Real generated annotated tag pointed to the generated commit
- Package validator accepted the exact generated 2.4.0 output
- No remote release ref changed during the local proof

This is hidden `ci` maintenance. It does not add a package changelog entry.