### PR TITLE
ci: pin shared workflows to v5.2.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ permissions:
 jobs:
   ci:
     name: CI
-    uses: agentjido/github-actions/.github/workflows/jido-ci.yml@v5.2.1
+    uses: agentjido/github-actions/.github/workflows/jido-ci.yml@v5.2.2
     with:
       docs_command: mix docs -f html
       test_command: mix coveralls

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ permissions:
 jobs:
   release:
     name: Release
-    uses: agentjido/github-actions/.github/workflows/jido-release.yml@v5.2.1
+    uses: agentjido/github-actions/.github/workflows/jido-release.yml@v5.2.2
     with:
       operation: ${{ inputs.operation || 'auto' }}
       tag_name: ${{ inputs.tag_name || '' }}


### PR DESCRIPTION
Closes #120

## Outcome

Pin the Jido Browser CI and release callers to immutable shared actions tag `v5.2.2`.

## Why

GitHub could resolve the `v5.2.1` wrapper on pull requests, but its relative nested workflow calls failed before job creation on both `push` and ordinary `workflow_dispatch`. Shared `v5.2.2` uses explicit repository paths pinned to a full commit SHA for both nested CI workflows.

## Changes

- Pin `ci.yml` from `v5.2.1` to `v5.2.2`.
- Pin `release.yml` from `v5.2.1` to `v5.2.2`.
- Change no inputs, permissions, job names, package code, or changelog content.

## Verification

- Actionlint 1.7.7 passed.
- `git diff --check` passed.
- Shared 63-fixture suite passed on agentjido/github-actions#17.

After merge, both main `push` CI and ordinary `workflow_dispatch` CI must start and pass before the floating shared `v5` tag moves or Jido Browser 2.4.0 is published.