### PR TITLE
ci: update shared workflows to v5.2.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ permissions:
 jobs:
   ci:
     name: CI
-    uses: agentjido/github-actions/.github/workflows/jido-ci.yml@v5.2.2
+    uses: agentjido/github-actions/.github/workflows/jido-ci.yml@v5.2.3
     with:
       docs_command: mix docs -f html
       test_command: mix coveralls

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ permissions:
 jobs:
   release:
     name: Release
-    uses: agentjido/github-actions/.github/workflows/jido-release.yml@v5.2.2
+    uses: agentjido/github-actions/.github/workflows/jido-release.yml@v5.2.3
     with:
       operation: ${{ inputs.operation || 'auto' }}
       tag_name: ${{ inputs.tag_name || '' }}


### PR DESCRIPTION
Closes #122.

## Summary

- validate the exact shared protected-promotion fix commit in Jido Browser
- replace the temporary commit pin with immutable `v5.2.3` after the shared PR is merged and tagged
- keep CI and release on the same shared workflow release

This two-line PR contains no package or changelog change.

## Required proof

- normal Jido Browser pull-request suite on the exact shared commit
- shared release self-test
- final Jido Browser suite on `v5.2.3`
- main-branch consumer run before the floating `v5` tag moves
