### PR TITLE
ci(release): default tag-triggered publishes to direct mode

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
       skip_tests: ${{ inputs.skip_tests || false }}
       version_override: ${{ inputs.version_override || '' }}
       release_command: mix jido_browser.release --yes
-      staged_prepare: ${{ inputs.staged_prepare }}
+      staged_prepare: ${{ inputs.staged_prepare || false }}
       validation_workflow: ci.yml
       required_checks: '["AgentBrowser smoke","CI / Summary"]'
       release_changed_files: '["CHANGELOG.md","mix.exs"]'


### PR DESCRIPTION
Closes #124.

The v2.4.0 tag event exposed an empty Boolean caller input and failed before job creation. This one-line change gives non-dispatch events the explicit backward-compatible `false` value. `workflow_dispatch` keeps its declared `true` default.

Evidence:

- failed tag-event startup: https://github.com/agentjido/jido_browser/actions/runs/33174479532
- successful publish-only recovery: https://github.com/agentjido/jido_browser/actions/runs/33174578963
- published release: https://github.com/agentjido/jido_browser/releases/tag/v2.4.0

No package or changelog file changes.
