### PR TITLE
refactor!: convert browser action input schemas to static Zoi objects

### DIFF
--- a/lib/jido_browser/action.ex
+++ b/lib/jido_browser/action.ex
@@ -1,0 +1,28 @@
+defmodule Jido.Browser.Action do
+  @moduledoc false
+
+  defmacro __using__(opts) do
+    quote do
+      use Jido.Action, unquote(opts)
+
+      @impl Jido.Action
+      def on_after_validate_params(params) do
+        {:ok, Jido.Browser.Action.apply_schema_defaults(schema(), params)}
+      end
+    end
+  end
+
+  @doc false
+  @spec apply_schema_defaults(Zoi.schema(), map()) :: map()
+  def apply_schema_defaults(schema, params) when is_map(params) do
+    schema
+    |> Zoi.to_json_schema()
+    |> Map.get(:properties, %{})
+    |> Enum.reduce(params, fn {key, property}, acc ->
+      case Map.fetch(property, :default) do
+        {:ok, default} -> Map.put_new(acc, key, default)
+        :error -> acc
+      end
+    end)
+  end
+end

--- a/lib/jido_browser/actions/back.ex
+++ b/lib/jido_browser/actions/back.ex
@@ -12,15 +12,13 @@ defmodule Jido.Browser.Actions.Back do
 
   """
 
-  use Jido.Action,
+  use Jido.Browser.Action,
     name: "browser_back",
     description: "Navigate back in browser history",
     category: "Browser",
     tags: ["browser", "navigation", "history", "web"],
     vsn: "2.0.0",
-    schema: [
-      timeout: [type: :integer, doc: "Timeout in milliseconds"]
-    ]
+    schema: Zoi.object(%{timeout: Zoi.integer(description: "Timeout in milliseconds") |> Zoi.optional()})
 
   alias Jido.Browser.ActionHelpers
   alias Jido.Browser.Error

--- a/lib/jido_browser/actions/click.ex
+++ b/lib/jido_browser/actions/click.ex
@@ -13,17 +13,20 @@ defmodule Jido.Browser.Actions.Click do
 
   """
 
-  use Jido.Action,
+  use Jido.Browser.Action,
     name: "browser_click",
     description: "Click an element in the browser",
     category: "Browser",
     tags: ["browser", "interaction", "web"],
     vsn: "2.0.0",
-    schema: [
-      selector: [type: :string, required: true, doc: "CSS selector for the element to click"],
-      text: [type: :string, doc: "Optional text content to match within the selector"],
-      timeout: [type: :integer, doc: "Timeout in milliseconds"]
-    ]
+    schema:
+      Zoi.object(%{
+        selector: Zoi.string(description: "CSS selector for the element to click"),
+        text:
+          Zoi.string(description: "Optional text content to match within the selector")
+          |> Zoi.optional(),
+        timeout: Zoi.integer(description: "Timeout in milliseconds") |> Zoi.optional()
+      })
 
   alias Jido.Browser.ActionHelpers
   alias Jido.Browser.Error

--- a/lib/jido_browser/actions/close_tab.ex
+++ b/lib/jido_browser/actions/close_tab.ex
@@ -3,16 +3,17 @@ defmodule Jido.Browser.Actions.CloseTab do
   Jido Action for closing the current tab or a specific browser tab.
   """
 
-  use Jido.Action,
+  use Jido.Browser.Action,
     name: "browser_close_tab",
     description: "Close a browser tab",
     category: "Browser",
     tags: ["browser", "tabs", "session"],
     vsn: "2.0.0",
-    schema: [
-      index: [type: :integer, doc: "Optional tab index to close"],
-      timeout: [type: :integer, doc: "Timeout in milliseconds"]
-    ]
+    schema:
+      Zoi.object(%{
+        index: Zoi.integer(description: "Optional tab index to close") |> Zoi.optional(),
+        timeout: Zoi.integer(description: "Timeout in milliseconds") |> Zoi.optional()
+      })
 
   alias Jido.Browser.ActionHelpers
   alias Jido.Browser.Error

--- a/lib/jido_browser/actions/console.ex
+++ b/lib/jido_browser/actions/console.ex
@@ -3,15 +3,13 @@ defmodule Jido.Browser.Actions.Console do
   Jido Action for retrieving browser console messages.
   """
 
-  use Jido.Action,
+  use Jido.Browser.Action,
     name: "browser_console",
     description: "Read browser console messages",
     category: "Browser",
     tags: ["browser", "diagnostics", "console"],
     vsn: "2.0.0",
-    schema: [
-      timeout: [type: :integer, doc: "Timeout in milliseconds"]
-    ]
+    schema: Zoi.object(%{timeout: Zoi.integer(description: "Timeout in milliseconds") |> Zoi.optional()})
 
   alias Jido.Browser.ActionHelpers
   alias Jido.Browser.Error

--- a/lib/jido_browser/actions/end_session.ex
+++ b/lib/jido_browser/actions/end_session.ex
@@ -13,13 +13,13 @@ defmodule Jido.Browser.Actions.EndSession do
   Requires a browser session in context (via :session, :browser_session, or tool_context).
   """
 
-  use Jido.Action,
+  use Jido.Browser.Action,
     name: "browser_end_session",
     description: "End the current browser session",
     category: "Browser",
     tags: ["browser", "session", "lifecycle"],
     vsn: "2.0.0",
-    schema: []
+    schema: Zoi.object(%{})
 
   alias Jido.Browser.ActionHelpers
   alias Jido.Browser.Error

--- a/lib/jido_browser/actions/errors.ex
+++ b/lib/jido_browser/actions/errors.ex
@@ -3,15 +3,13 @@ defmodule Jido.Browser.Actions.Errors do
   Jido Action for retrieving browser/runtime errors.
   """
 
-  use Jido.Action,
+  use Jido.Browser.Action,
     name: "browser_errors",
     description: "Read browser runtime errors",
     category: "Browser",
     tags: ["browser", "diagnostics", "errors"],
     vsn: "2.0.0",
-    schema: [
-      timeout: [type: :integer, doc: "Timeout in milliseconds"]
-    ]
+    schema: Zoi.object(%{timeout: Zoi.integer(description: "Timeout in milliseconds") |> Zoi.optional()})
 
   alias Jido.Browser.ActionHelpers
   alias Jido.Browser.Error

--- a/lib/jido_browser/actions/evaluate.ex
+++ b/lib/jido_browser/actions/evaluate.ex
@@ -13,16 +13,17 @@ defmodule Jido.Browser.Actions.Evaluate do
 
   """
 
-  use Jido.Action,
+  use Jido.Browser.Action,
     name: "browser_evaluate",
     description: "Execute JavaScript in the browser and return the result",
     category: "Browser",
     tags: ["browser", "javascript", "evaluate", "web"],
     vsn: "2.0.0",
-    schema: [
-      script: [type: :string, required: true, doc: "JavaScript code to execute"],
-      timeout: [type: :integer, doc: "Timeout in milliseconds"]
-    ]
+    schema:
+      Zoi.object(%{
+        script: Zoi.string(description: "JavaScript code to execute"),
+        timeout: Zoi.integer(description: "Timeout in milliseconds") |> Zoi.optional()
+      })
 
   alias Jido.Browser.ActionHelpers
   alias Jido.Browser.Error

--- a/lib/jido_browser/actions/extract_content.ex
+++ b/lib/jido_browser/actions/extract_content.ex
@@ -18,16 +18,23 @@ defmodule Jido.Browser.Actions.ExtractContent do
 
   """
 
-  use Jido.Action,
+  use Jido.Browser.Action,
     name: "browser_extract_content",
     description: "Extract content from the current page as markdown, HTML, or text",
     category: "Browser",
     tags: ["browser", "content", "extract", "markdown", "web"],
     vsn: "2.0.0",
-    schema: [
-      selector: [type: :string, default: "body", doc: "CSS selector to scope extraction"],
-      format: [type: {:in, [:markdown, :html, :text]}, default: :markdown, doc: "Output format"]
-    ]
+    schema:
+      Zoi.object(%{
+        selector:
+          Zoi.string(description: "CSS selector to scope extraction")
+          |> Zoi.default("body")
+          |> Zoi.optional(),
+        format:
+          Zoi.enum([:markdown, :html, :text], description: "Output format")
+          |> Zoi.default(:markdown)
+          |> Zoi.optional()
+      })
 
   alias Jido.Browser.ActionHelpers
   alias Jido.Browser.Error

--- a/lib/jido_browser/actions/fetch_rich.ex
+++ b/lib/jido_browser/actions/fetch_rich.ex
@@ -3,42 +3,81 @@ defmodule Jido.Browser.Actions.FetchRich do
   Agent-oriented URL retrieval with HTTP-first fetching and optional browser fallback.
   """
 
-  use Jido.Action,
+  use Jido.Browser.Action,
     name: "fetch_rich",
     description:
       "Fetch a URL with normalized rich content, using fast HTTP retrieval first and optional browser fallback.",
     category: "Browser",
     tags: ["browser", "web", "fetch", "retrieval", "agent"],
     vsn: "2.0.0",
-    schema: [
-      url: [type: :string, required: true, doc: "The URL to fetch"],
-      format: [type: {:in, [:markdown, :text, :html]}, default: :markdown, doc: "Output format"],
-      backend: [type: {:in, [:req, :browsey]}, doc: "Preferred HTTP backend"],
-      http_backends: [type: {:list, :atom}, doc: "HTTP backend sequence, such as [:req, :browsey]"],
-      selector: [type: :string, doc: "Optional CSS selector for HTML/browser extraction"],
-      allowed_domains: [type: {:list, :string}, default: [], doc: "Allow-list of host or host/path rules"],
-      blocked_domains: [type: {:list, :string}, default: [], doc: "Block-list of host or host/path rules"],
-      allow_private_network: [type: :boolean, default: false, doc: "Allow private network destinations"],
-      focus_terms: [type: {:list, :string}, default: [], doc: "Terms used to filter fetched documents"],
-      focus_window: [type: :integer, default: 0, doc: "Paragraph window around each focus match"],
-      max_content_tokens: [type: :integer, doc: "Approximate token cap for returned content"],
-      max_response_bytes: [
-        type: :timeout,
-        default: 5 * 1024 * 1024,
-        doc: "Positive response byte cap, or infinity to disable the cap"
-      ],
-      citations: [type: :boolean, default: false, doc: "Include citation-ready passage offsets"],
-      cache: [type: :boolean, default: true, doc: "Reuse cached fetch results when available"],
-      timeout: [type: :integer, doc: "Timeout in milliseconds"],
-      browser_fallback: [type: :boolean, default: false, doc: "Allow fallback to a browser session"],
-      pool: [type: :any, doc: "Optional warm browser pool used for browser fallback"],
-      checkout_timeout: [type: :integer, doc: "Warm pool checkout timeout in ms"],
-      adapter: [type: :atom, doc: "Browser adapter module for fallback"],
-      headless: [type: :boolean, doc: "Run fallback browser headless"],
-      require_known_url: [type: :boolean, default: false, doc: "Require the URL to be present in context"],
-      known_urls: [type: {:list, :string}, default: [], doc: "Additional known URLs accepted for provenance"],
-      max_uses: [type: :integer, doc: "Maximum successful rich fetch calls allowed in current skill state"]
-    ]
+    schema:
+      Zoi.object(%{
+        url: Zoi.string(description: "The URL to fetch"),
+        format:
+          Zoi.enum([:markdown, :text, :html], description: "Output format")
+          |> Zoi.default(:markdown)
+          |> Zoi.optional(),
+        backend: Zoi.enum([:req, :browsey], description: "Preferred HTTP backend") |> Zoi.optional(),
+        http_backends:
+          Zoi.list(Zoi.atom(), description: "HTTP backend sequence, such as [:req, :browsey]")
+          |> Zoi.optional(),
+        selector: Zoi.string(description: "Optional CSS selector for HTML/browser extraction") |> Zoi.optional(),
+        allowed_domains:
+          Zoi.list(Zoi.string(), description: "Allow-list of host or host/path rules")
+          |> Zoi.default([])
+          |> Zoi.optional(),
+        blocked_domains:
+          Zoi.list(Zoi.string(), description: "Block-list of host or host/path rules")
+          |> Zoi.default([])
+          |> Zoi.optional(),
+        allow_private_network:
+          Zoi.boolean(description: "Allow private network destinations")
+          |> Zoi.default(false)
+          |> Zoi.optional(),
+        focus_terms:
+          Zoi.list(Zoi.string(), description: "Terms used to filter fetched documents")
+          |> Zoi.default([])
+          |> Zoi.optional(),
+        focus_window:
+          Zoi.integer(description: "Paragraph window around each focus match")
+          |> Zoi.default(0)
+          |> Zoi.optional(),
+        max_content_tokens: Zoi.integer(description: "Approximate token cap for returned content") |> Zoi.optional(),
+        max_response_bytes:
+          Zoi.union([Zoi.integer() |> Zoi.min(0), Zoi.literal(:infinity)],
+            description: "Positive response byte cap, or infinity to disable the cap"
+          )
+          |> Zoi.default(5 * 1024 * 1024)
+          |> Zoi.optional(),
+        citations:
+          Zoi.boolean(description: "Include citation-ready passage offsets")
+          |> Zoi.default(false)
+          |> Zoi.optional(),
+        cache:
+          Zoi.boolean(description: "Reuse cached fetch results when available")
+          |> Zoi.default(true)
+          |> Zoi.optional(),
+        timeout: Zoi.integer(description: "Timeout in milliseconds") |> Zoi.optional(),
+        browser_fallback:
+          Zoi.boolean(description: "Allow fallback to a browser session")
+          |> Zoi.default(false)
+          |> Zoi.optional(),
+        pool: Zoi.any(description: "Optional warm browser pool used for browser fallback") |> Zoi.optional(),
+        checkout_timeout: Zoi.integer(description: "Warm pool checkout timeout in ms") |> Zoi.optional(),
+        adapter: Zoi.atom(description: "Browser adapter module for fallback") |> Zoi.optional(),
+        headless: Zoi.boolean(description: "Run fallback browser headless") |> Zoi.optional(),
+        require_known_url:
+          Zoi.boolean(description: "Require the URL to be present in context")
+          |> Zoi.default(false)
+          |> Zoi.optional(),
+        known_urls:
+          Zoi.list(Zoi.string(), description: "Additional known URLs accepted for provenance")
+          |> Zoi.default([])
+          |> Zoi.optional(),
+        max_uses:
+          Zoi.integer(description: "Maximum successful rich fetch calls allowed in current skill state")
+          |> Zoi.optional()
+      })
 
   alias Jido.Browser.Error
 

--- a/lib/jido_browser/actions/focus.ex
+++ b/lib/jido_browser/actions/focus.ex
@@ -13,16 +13,17 @@ defmodule Jido.Browser.Actions.Focus do
 
   """
 
-  use Jido.Action,
+  use Jido.Browser.Action,
     name: "browser_focus",
     description: "Focus on an element in the browser",
     category: "Browser",
     tags: ["browser", "interaction", "focus", "web"],
     vsn: "2.0.0",
-    schema: [
-      selector: [type: :string, required: true, doc: "CSS selector for the element to focus"],
-      timeout: [type: :integer, doc: "Timeout in milliseconds"]
-    ]
+    schema:
+      Zoi.object(%{
+        selector: Zoi.string(description: "CSS selector for the element to focus"),
+        timeout: Zoi.integer(description: "Timeout in milliseconds") |> Zoi.optional()
+      })
 
   alias Jido.Browser.ActionHelpers
   alias Jido.Browser.Error

--- a/lib/jido_browser/actions/forward.ex
+++ b/lib/jido_browser/actions/forward.ex
@@ -12,15 +12,13 @@ defmodule Jido.Browser.Actions.Forward do
 
   """
 
-  use Jido.Action,
+  use Jido.Browser.Action,
     name: "browser_forward",
     description: "Navigate forward in browser history",
     category: "Browser",
     tags: ["browser", "navigation", "history", "web"],
     vsn: "2.0.0",
-    schema: [
-      timeout: [type: :integer, doc: "Timeout in milliseconds"]
-    ]
+    schema: Zoi.object(%{timeout: Zoi.integer(description: "Timeout in milliseconds") |> Zoi.optional()})
 
   alias Jido.Browser.ActionHelpers
   alias Jido.Browser.Error

--- a/lib/jido_browser/actions/get_attribute.ex
+++ b/lib/jido_browser/actions/get_attribute.ex
@@ -13,16 +13,17 @@ defmodule Jido.Browser.Actions.GetAttribute do
 
   """
 
-  use Jido.Action,
+  use Jido.Browser.Action,
     name: "browser_get_attribute",
     description: "Get an attribute value from an element",
     category: "Browser",
     tags: ["browser", "query", "web"],
     vsn: "2.0.0",
-    schema: [
-      selector: [type: :string, required: true, doc: "CSS selector for the element"],
-      attribute: [type: :string, required: true, doc: "Attribute name to get"]
-    ]
+    schema:
+      Zoi.object(%{
+        selector: Zoi.string(description: "CSS selector for the element"),
+        attribute: Zoi.string(description: "Attribute name to get")
+      })
 
   alias Jido.Browser.ActionHelpers
   alias Jido.Browser.Error

--- a/lib/jido_browser/actions/get_status.ex
+++ b/lib/jido_browser/actions/get_status.ex
@@ -14,13 +14,13 @@ defmodule Jido.Browser.Actions.GetStatus do
   Requires a browser session in context (via :session, :browser_session, or tool_context).
   """
 
-  use Jido.Action,
+  use Jido.Browser.Action,
     name: "browser_get_status",
     description: "Get current session status (url, title, is_alive)",
     category: "Browser",
     tags: ["browser", "session", "status"],
     vsn: "2.0.0",
-    schema: []
+    schema: Zoi.object(%{})
 
   alias Jido.Browser.ActionHelpers
 

--- a/lib/jido_browser/actions/get_text.ex
+++ b/lib/jido_browser/actions/get_text.ex
@@ -13,16 +13,20 @@ defmodule Jido.Browser.Actions.GetText do
 
   """
 
-  use Jido.Action,
+  use Jido.Browser.Action,
     name: "browser_get_text",
     description: "Get text content of an element",
     category: "Browser",
     tags: ["browser", "query", "web"],
     vsn: "2.0.0",
-    schema: [
-      selector: [type: :string, required: true, doc: "CSS selector for the element"],
-      all: [type: :boolean, default: false, doc: "Get text from all matching elements"]
-    ]
+    schema:
+      Zoi.object(%{
+        selector: Zoi.string(description: "CSS selector for the element"),
+        all:
+          Zoi.boolean(description: "Get text from all matching elements")
+          |> Zoi.default(false)
+          |> Zoi.optional()
+      })
 
   alias Jido.Browser.ActionHelpers
   alias Jido.Browser.Error

--- a/lib/jido_browser/actions/get_title.ex
+++ b/lib/jido_browser/actions/get_title.ex
@@ -12,15 +12,13 @@ defmodule Jido.Browser.Actions.GetTitle do
 
   """
 
-  use Jido.Action,
+  use Jido.Browser.Action,
     name: "browser_get_title",
     description: "Get the current page title",
     category: "Browser",
     tags: ["browser", "navigation", "web"],
     vsn: "2.0.0",
-    schema: [
-      timeout: [type: :integer, doc: "Timeout in milliseconds"]
-    ]
+    schema: Zoi.object(%{timeout: Zoi.integer(description: "Timeout in milliseconds") |> Zoi.optional()})
 
   alias Jido.Browser.ActionHelpers
   alias Jido.Browser.Error

--- a/lib/jido_browser/actions/get_url.ex
+++ b/lib/jido_browser/actions/get_url.ex
@@ -12,15 +12,13 @@ defmodule Jido.Browser.Actions.GetUrl do
 
   """
 
-  use Jido.Action,
+  use Jido.Browser.Action,
     name: "browser_get_url",
     description: "Get the current page URL",
     category: "Browser",
     tags: ["browser", "navigation", "web"],
     vsn: "2.0.0",
-    schema: [
-      timeout: [type: :integer, doc: "Timeout in milliseconds"]
-    ]
+    schema: Zoi.object(%{timeout: Zoi.integer(description: "Timeout in milliseconds") |> Zoi.optional()})
 
   alias Jido.Browser.ActionHelpers
   alias Jido.Browser.Error

--- a/lib/jido_browser/actions/hover.ex
+++ b/lib/jido_browser/actions/hover.ex
@@ -13,16 +13,17 @@ defmodule Jido.Browser.Actions.Hover do
 
   """
 
-  use Jido.Action,
+  use Jido.Browser.Action,
     name: "browser_hover",
     description: "Hover over an element in the browser",
     category: "Browser",
     tags: ["browser", "interaction", "hover", "web"],
     vsn: "2.0.0",
-    schema: [
-      selector: [type: :string, required: true, doc: "CSS selector for the element to hover"],
-      timeout: [type: :integer, doc: "Timeout in milliseconds"]
-    ]
+    schema:
+      Zoi.object(%{
+        selector: Zoi.string(description: "CSS selector for the element to hover"),
+        timeout: Zoi.integer(description: "Timeout in milliseconds") |> Zoi.optional()
+      })
 
   alias Jido.Browser.ActionHelpers
   alias Jido.Browser.Error

--- a/lib/jido_browser/actions/is_visible.ex
+++ b/lib/jido_browser/actions/is_visible.ex
@@ -13,15 +13,13 @@ defmodule Jido.Browser.Actions.IsVisible do
 
   """
 
-  use Jido.Action,
+  use Jido.Browser.Action,
     name: "browser_is_visible",
     description: "Check if an element is visible",
     category: "Browser",
     tags: ["browser", "query", "web"],
     vsn: "2.0.0",
-    schema: [
-      selector: [type: :string, required: true, doc: "CSS selector for the element"]
-    ]
+    schema: Zoi.object(%{selector: Zoi.string(description: "CSS selector for the element")})
 
   alias Jido.Browser.ActionHelpers
   alias Jido.Browser.Error

--- a/lib/jido_browser/actions/list_tabs.ex
+++ b/lib/jido_browser/actions/list_tabs.ex
@@ -3,15 +3,13 @@ defmodule Jido.Browser.Actions.ListTabs do
   Jido Action for listing the tabs in the current browser session.
   """
 
-  use Jido.Action,
+  use Jido.Browser.Action,
     name: "browser_list_tabs",
     description: "List open browser tabs",
     category: "Browser",
     tags: ["browser", "tabs", "session"],
     vsn: "2.0.0",
-    schema: [
-      timeout: [type: :integer, doc: "Timeout in milliseconds"]
-    ]
+    schema: Zoi.object(%{timeout: Zoi.integer(description: "Timeout in milliseconds") |> Zoi.optional()})
 
   alias Jido.Browser.ActionHelpers
   alias Jido.Browser.Error

--- a/lib/jido_browser/actions/load_state.ex
+++ b/lib/jido_browser/actions/load_state.ex
@@ -3,16 +3,17 @@ defmodule Jido.Browser.Actions.LoadState do
   Jido Action for restoring browser session state from disk.
   """
 
-  use Jido.Action,
+  use Jido.Browser.Action,
     name: "browser_load_state",
     description: "Load browser session state from a file",
     category: "Browser",
     tags: ["browser", "state", "session"],
     vsn: "2.0.0",
-    schema: [
-      path: [type: :string, required: true, doc: "Filesystem path of the saved session state"],
-      timeout: [type: :integer, doc: "Timeout in milliseconds"]
-    ]
+    schema:
+      Zoi.object(%{
+        path: Zoi.string(description: "Filesystem path of the saved session state"),
+        timeout: Zoi.integer(description: "Timeout in milliseconds") |> Zoi.optional()
+      })
 
   alias Jido.Browser.ActionHelpers
   alias Jido.Browser.Error

--- a/lib/jido_browser/actions/navigate.ex
+++ b/lib/jido_browser/actions/navigate.ex
@@ -12,16 +12,17 @@ defmodule Jido.Browser.Actions.Navigate do
 
   """
 
-  use Jido.Action,
+  use Jido.Browser.Action,
     name: "browser_navigate",
     description: "Navigate the browser to a URL",
     category: "Browser",
     tags: ["browser", "navigation", "web"],
     vsn: "2.0.0",
-    schema: [
-      url: [type: :string, required: true, doc: "The URL to navigate to"],
-      timeout: [type: :integer, doc: "Timeout in milliseconds"]
-    ]
+    schema:
+      Zoi.object(%{
+        url: Zoi.string(description: "The URL to navigate to"),
+        timeout: Zoi.integer(description: "Timeout in milliseconds") |> Zoi.optional()
+      })
 
   alias Jido.Browser.ActionHelpers
   alias Jido.Browser.Error

--- a/lib/jido_browser/actions/new_tab.ex
+++ b/lib/jido_browser/actions/new_tab.ex
@@ -3,16 +3,17 @@ defmodule Jido.Browser.Actions.NewTab do
   Jido Action for opening a new browser tab.
   """
 
-  use Jido.Action,
+  use Jido.Browser.Action,
     name: "browser_new_tab",
     description: "Open a new browser tab",
     category: "Browser",
     tags: ["browser", "tabs", "navigation"],
     vsn: "2.0.0",
-    schema: [
-      url: [type: :string, doc: "Optional URL to open in the new tab"],
-      timeout: [type: :integer, doc: "Timeout in milliseconds"]
-    ]
+    schema:
+      Zoi.object(%{
+        url: Zoi.string(description: "Optional URL to open in the new tab") |> Zoi.optional(),
+        timeout: Zoi.integer(description: "Timeout in milliseconds") |> Zoi.optional()
+      })
 
   alias Jido.Browser.ActionHelpers
   alias Jido.Browser.Error

--- a/lib/jido_browser/actions/pool_status.ex
+++ b/lib/jido_browser/actions/pool_status.ex
@@ -3,15 +3,18 @@ defmodule Jido.Browser.Actions.PoolStatus do
   Jido Action for inspecting a warm browser pool.
   """
 
-  use Jido.Action,
+  use Jido.Browser.Action,
     name: "browser_pool_status",
     description: "Return readiness and lifecycle status for a warm browser pool.",
     category: "Browser",
     tags: ["browser", "pool", "status", "diagnostics"],
     vsn: "2.0.0",
-    schema: [
-      pool: [type: :any, doc: "Warm pool name or pid. Defaults to plugin pool state."]
-    ]
+    schema:
+      Zoi.object(%{
+        pool:
+          Zoi.any(description: "Warm pool name or pid. Defaults to plugin pool state.")
+          |> Zoi.optional()
+      })
 
   alias Jido.Browser.Error
 

--- a/lib/jido_browser/actions/query.ex
+++ b/lib/jido_browser/actions/query.ex
@@ -13,16 +13,20 @@ defmodule Jido.Browser.Actions.Query do
 
   """
 
-  use Jido.Action,
+  use Jido.Browser.Action,
     name: "browser_query",
     description: "Query for elements matching a CSS selector",
     category: "Browser",
     tags: ["browser", "query", "web"],
     vsn: "2.0.0",
-    schema: [
-      selector: [type: :string, required: true, doc: "CSS selector to query"],
-      limit: [type: :integer, default: 10, doc: "Maximum number of elements to return"]
-    ]
+    schema:
+      Zoi.object(%{
+        selector: Zoi.string(description: "CSS selector to query"),
+        limit:
+          Zoi.integer(description: "Maximum number of elements to return")
+          |> Zoi.default(10)
+          |> Zoi.optional()
+      })
 
   alias Jido.Browser.ActionHelpers
   alias Jido.Browser.Error

--- a/lib/jido_browser/actions/read_page.ex
+++ b/lib/jido_browser/actions/read_page.ex
@@ -15,7 +15,7 @@ defmodule Jido.Browser.Actions.ReadPage do
 
   """
 
-  use Jido.Action,
+  use Jido.Browser.Action,
     name: "read_page",
     description:
       "Read a web page and return its content as markdown, text, or HTML. " <>
@@ -23,20 +23,23 @@ defmodule Jido.Browser.Actions.ReadPage do
     category: "Browser",
     tags: ["browser", "web", "read", "content", "markdown"],
     vsn: "2.0.0",
-    schema: [
-      url: [type: :string, required: true, doc: "The URL to read"],
-      selector: [type: :string, default: "body", doc: "CSS selector to scope extraction"],
-      format: [
-        type: {:in, [:markdown, :text, :html]},
-        default: :markdown,
-        doc: "Output format"
-      ],
-      pool: [type: :any, doc: "Optional warm session pool name"],
-      checkout_timeout: [type: :integer, doc: "Warm pool checkout timeout in ms"],
-      adapter: [type: :atom, doc: "Browser adapter module"],
-      headless: [type: :boolean, doc: "Run in headless mode"],
-      timeout: [type: :integer, doc: "Default browser timeout in ms"]
-    ]
+    schema:
+      Zoi.object(%{
+        url: Zoi.string(description: "The URL to read"),
+        selector:
+          Zoi.string(description: "CSS selector to scope extraction")
+          |> Zoi.default("body")
+          |> Zoi.optional(),
+        format:
+          Zoi.enum([:markdown, :text, :html], description: "Output format")
+          |> Zoi.default(:markdown)
+          |> Zoi.optional(),
+        pool: Zoi.any(description: "Optional warm session pool name") |> Zoi.optional(),
+        checkout_timeout: Zoi.integer(description: "Warm pool checkout timeout in ms") |> Zoi.optional(),
+        adapter: Zoi.atom(description: "Browser adapter module") |> Zoi.optional(),
+        headless: Zoi.boolean(description: "Run in headless mode") |> Zoi.optional(),
+        timeout: Zoi.integer(description: "Default browser timeout in ms") |> Zoi.optional()
+      })
 
   @impl true
   def run(params, context) do

--- a/lib/jido_browser/actions/reload.ex
+++ b/lib/jido_browser/actions/reload.ex
@@ -12,15 +12,13 @@ defmodule Jido.Browser.Actions.Reload do
 
   """
 
-  use Jido.Action,
+  use Jido.Browser.Action,
     name: "browser_reload",
     description: "Reload the current page",
     category: "Browser",
     tags: ["browser", "navigation", "web"],
     vsn: "2.0.0",
-    schema: [
-      timeout: [type: :integer, doc: "Timeout in milliseconds"]
-    ]
+    schema: Zoi.object(%{timeout: Zoi.integer(description: "Timeout in milliseconds") |> Zoi.optional()})
 
   alias Jido.Browser.ActionHelpers
   alias Jido.Browser.Error

--- a/lib/jido_browser/actions/save_state.ex
+++ b/lib/jido_browser/actions/save_state.ex
@@ -3,16 +3,17 @@ defmodule Jido.Browser.Actions.SaveState do
   Jido Action for persisting the current browser session state to disk.
   """
 
-  use Jido.Action,
+  use Jido.Browser.Action,
     name: "browser_save_state",
     description: "Save browser session state to a file",
     category: "Browser",
     tags: ["browser", "state", "session"],
     vsn: "2.0.0",
-    schema: [
-      path: [type: :string, required: true, doc: "Filesystem path where session state will be stored"],
-      timeout: [type: :integer, doc: "Timeout in milliseconds"]
-    ]
+    schema:
+      Zoi.object(%{
+        path: Zoi.string(description: "Filesystem path where session state will be stored"),
+        timeout: Zoi.integer(description: "Timeout in milliseconds") |> Zoi.optional()
+      })
 
   alias Jido.Browser.ActionHelpers
   alias Jido.Browser.Error

--- a/lib/jido_browser/actions/screenshot.ex
+++ b/lib/jido_browser/actions/screenshot.ex
@@ -13,17 +13,24 @@ defmodule Jido.Browser.Actions.Screenshot do
 
   """
 
-  use Jido.Action,
+  use Jido.Browser.Action,
     name: "browser_screenshot",
     description: "Take a screenshot of the current page",
     category: "Browser",
     tags: ["browser", "screenshot", "capture", "web"],
     vsn: "2.0.0",
-    schema: [
-      full_page: [type: :boolean, default: false, doc: "Capture the full scrollable page"],
-      format: [type: {:in, [:png]}, default: :png, doc: "Image format (only PNG is currently supported)"],
-      save_path: [type: :string, doc: "Optional file path to save the screenshot"]
-    ]
+    schema:
+      Zoi.object(%{
+        full_page:
+          Zoi.boolean(description: "Capture the full scrollable page")
+          |> Zoi.default(false)
+          |> Zoi.optional(),
+        format:
+          Zoi.enum([:png], description: "Image format (only PNG is currently supported)")
+          |> Zoi.default(:png)
+          |> Zoi.optional(),
+        save_path: Zoi.string(description: "Optional file path to save the screenshot") |> Zoi.optional()
+      })
 
   alias Jido.Browser.ActionHelpers
   alias Jido.Browser.Error

--- a/lib/jido_browser/actions/scroll.ex
+++ b/lib/jido_browser/actions/scroll.ex
@@ -15,21 +15,21 @@ defmodule Jido.Browser.Actions.Scroll do
 
   """
 
-  use Jido.Action,
+  use Jido.Browser.Action,
     name: "browser_scroll",
     description: "Scroll the page by pixels, to preset positions, or to an element",
     category: "Browser",
     tags: ["browser", "interaction", "scroll", "web"],
     vsn: "2.0.0",
-    schema: [
-      x: [type: :integer, doc: "Horizontal scroll pixels"],
-      y: [type: :integer, doc: "Vertical scroll pixels"],
-      direction: [
-        type: {:in, [:up, :down, :top, :bottom]},
-        doc: "Preset scroll direction"
-      ],
-      selector: [type: :string, doc: "CSS selector to scroll element into view"]
-    ]
+    schema:
+      Zoi.object(%{
+        x: Zoi.integer(description: "Horizontal scroll pixels") |> Zoi.optional(),
+        y: Zoi.integer(description: "Vertical scroll pixels") |> Zoi.optional(),
+        direction:
+          Zoi.enum([:up, :down, :top, :bottom], description: "Preset scroll direction")
+          |> Zoi.optional(),
+        selector: Zoi.string(description: "CSS selector to scroll element into view") |> Zoi.optional()
+      })
 
   alias Jido.Browser.ActionHelpers
   alias Jido.Browser.Error

--- a/lib/jido_browser/actions/search_web.ex
+++ b/lib/jido_browser/actions/search_web.ex
@@ -18,7 +18,7 @@ defmodule Jido.Browser.Actions.SearchWeb do
 
   """
 
-  use Jido.Action,
+  use Jido.Browser.Action,
     name: "search_web",
     description:
       "Search the web using Brave Search API and return structured results " <>
@@ -26,13 +26,22 @@ defmodule Jido.Browser.Actions.SearchWeb do
     category: "Browser",
     tags: ["browser", "web", "search", "brave"],
     vsn: "2.0.0",
-    schema: [
-      query: [type: :string, required: true, doc: "Search query"],
-      max_results: [type: :integer, default: 10, doc: "Maximum number of results to return (max 20)"],
-      country: [type: :string, default: "us", doc: "Country code for results (e.g. us, gb, de)"],
-      search_lang: [type: :string, default: "en", doc: "Language code for results"],
-      freshness: [type: :string, doc: "Freshness filter: pd (24h), pw (week), pm (month), py (year)"]
-    ]
+    schema:
+      Zoi.object(%{
+        query: Zoi.string(description: "Search query"),
+        max_results:
+          Zoi.integer(description: "Maximum number of results to return (max 20)")
+          |> Zoi.default(10)
+          |> Zoi.optional(),
+        country:
+          Zoi.string(description: "Country code for results (e.g. us, gb, de)")
+          |> Zoi.default("us")
+          |> Zoi.optional(),
+        search_lang: Zoi.string(description: "Language code for results") |> Zoi.default("en") |> Zoi.optional(),
+        freshness:
+          Zoi.string(description: "Freshness filter: pd (24h), pw (week), pm (month), py (year)")
+          |> Zoi.optional()
+      })
 
   @brave_api_url "https://api.search.brave.com/res/v1/web/search"
 

--- a/lib/jido_browser/actions/select_option.ex
+++ b/lib/jido_browser/actions/select_option.ex
@@ -14,18 +14,19 @@ defmodule Jido.Browser.Actions.SelectOption do
 
   """
 
-  use Jido.Action,
+  use Jido.Browser.Action,
     name: "browser_select_option",
     description: "Select an option from a dropdown element",
     category: "Browser",
     tags: ["browser", "interaction", "select", "form", "web"],
     vsn: "2.0.0",
-    schema: [
-      selector: [type: :string, required: true, doc: "CSS selector for the select element"],
-      value: [type: :string, doc: "Option value to select"],
-      label: [type: :string, doc: "Option label/text to select"],
-      index: [type: :integer, doc: "Option index to select (0-based)"]
-    ]
+    schema:
+      Zoi.object(%{
+        selector: Zoi.string(description: "CSS selector for the select element"),
+        value: Zoi.string(description: "Option value to select") |> Zoi.optional(),
+        label: Zoi.string(description: "Option label/text to select") |> Zoi.optional(),
+        index: Zoi.integer(description: "Option index to select (0-based)") |> Zoi.optional()
+      })
 
   alias Jido.Browser.ActionHelpers
   alias Jido.Browser.Error

--- a/lib/jido_browser/actions/snapshot.ex
+++ b/lib/jido_browser/actions/snapshot.ex
@@ -18,19 +18,26 @@ defmodule Jido.Browser.Actions.Snapshot do
 
   """
 
-  use Jido.Action,
+  use Jido.Browser.Action,
     name: "browser_snapshot",
     description: "Get comprehensive LLM-friendly snapshot of the current page state",
     category: "Browser",
     tags: ["browser", "snapshot", "observe", "page", "web", "ai"],
     vsn: "2.0.0",
-    schema: [
-      include_links: [type: :boolean, default: true, doc: "Include extracted links"],
-      include_forms: [type: :boolean, default: true, doc: "Include form field info"],
-      include_headings: [type: :boolean, default: true, doc: "Include heading structure"],
-      max_content_length: [type: :integer, default: 50_000, doc: "Truncate content at this length"],
-      selector: [type: :string, default: "body", doc: "CSS selector to scope extraction"]
-    ]
+    schema:
+      Zoi.object(%{
+        include_links: Zoi.boolean(description: "Include extracted links") |> Zoi.default(true) |> Zoi.optional(),
+        include_forms: Zoi.boolean(description: "Include form field info") |> Zoi.default(true) |> Zoi.optional(),
+        include_headings: Zoi.boolean(description: "Include heading structure") |> Zoi.default(true) |> Zoi.optional(),
+        max_content_length:
+          Zoi.integer(description: "Truncate content at this length")
+          |> Zoi.default(50_000)
+          |> Zoi.optional(),
+        selector:
+          Zoi.string(description: "CSS selector to scope extraction")
+          |> Zoi.default("body")
+          |> Zoi.optional()
+      })
 
   alias Jido.Browser.ActionHelpers
   alias Jido.Browser.Error

--- a/lib/jido_browser/actions/snapshot_url.ex
+++ b/lib/jido_browser/actions/snapshot_url.ex
@@ -21,7 +21,7 @@ defmodule Jido.Browser.Actions.SnapshotUrl do
 
   """
 
-  use Jido.Action,
+  use Jido.Browser.Action,
     name: "snapshot_url",
     description:
       "Navigate to a URL and return a comprehensive LLM-friendly snapshot " <>
@@ -29,19 +29,26 @@ defmodule Jido.Browser.Actions.SnapshotUrl do
     category: "Browser",
     tags: ["browser", "web", "snapshot", "observe", "ai"],
     vsn: "2.0.0",
-    schema: [
-      url: [type: :string, required: true, doc: "The URL to snapshot"],
-      selector: [type: :string, default: "body", doc: "CSS selector to scope extraction"],
-      include_links: [type: :boolean, default: true, doc: "Include extracted links"],
-      include_forms: [type: :boolean, default: true, doc: "Include form field info"],
-      include_headings: [type: :boolean, default: true, doc: "Include heading structure"],
-      max_content_length: [type: :integer, default: 50_000, doc: "Truncate content at this length"],
-      pool: [type: :any, doc: "Optional warm session pool name"],
-      checkout_timeout: [type: :integer, doc: "Warm pool checkout timeout in ms"],
-      adapter: [type: :atom, doc: "Browser adapter module"],
-      headless: [type: :boolean, doc: "Run in headless mode"],
-      timeout: [type: :integer, doc: "Default browser timeout in ms"]
-    ]
+    schema:
+      Zoi.object(%{
+        url: Zoi.string(description: "The URL to snapshot"),
+        selector:
+          Zoi.string(description: "CSS selector to scope extraction")
+          |> Zoi.default("body")
+          |> Zoi.optional(),
+        include_links: Zoi.boolean(description: "Include extracted links") |> Zoi.default(true) |> Zoi.optional(),
+        include_forms: Zoi.boolean(description: "Include form field info") |> Zoi.default(true) |> Zoi.optional(),
+        include_headings: Zoi.boolean(description: "Include heading structure") |> Zoi.default(true) |> Zoi.optional(),
+        max_content_length:
+          Zoi.integer(description: "Truncate content at this length")
+          |> Zoi.default(50_000)
+          |> Zoi.optional(),
+        pool: Zoi.any(description: "Optional warm session pool name") |> Zoi.optional(),
+        checkout_timeout: Zoi.integer(description: "Warm pool checkout timeout in ms") |> Zoi.optional(),
+        adapter: Zoi.atom(description: "Browser adapter module") |> Zoi.optional(),
+        headless: Zoi.boolean(description: "Run in headless mode") |> Zoi.optional(),
+        timeout: Zoi.integer(description: "Default browser timeout in ms") |> Zoi.optional()
+      })
 
   alias Jido.Browser.ActionHelpers
 

--- a/lib/jido_browser/actions/start_session.ex
+++ b/lib/jido_browser/actions/start_session.ex
@@ -13,19 +13,20 @@ defmodule Jido.Browser.Actions.StartSession do
   The returned session should be stored in skill state for use by other browser actions.
   """
 
-  use Jido.Action,
+  use Jido.Browser.Action,
     name: "browser_start_session",
     description: "Start a new browser session",
     category: "Browser",
     tags: ["browser", "session", "lifecycle"],
     vsn: "2.0.0",
-    schema: [
-      headless: [type: :boolean, doc: "Run in headless mode"],
-      timeout: [type: :integer, doc: "Default timeout in ms"],
-      adapter: [type: :atom, doc: "Browser adapter module"],
-      pool: [type: :any, doc: "Optional warm session pool name"],
-      checkout_timeout: [type: :integer, doc: "Warm pool checkout timeout in ms"]
-    ]
+    schema:
+      Zoi.object(%{
+        headless: Zoi.boolean(description: "Run in headless mode") |> Zoi.optional(),
+        timeout: Zoi.integer(description: "Default timeout in ms") |> Zoi.optional(),
+        adapter: Zoi.atom(description: "Browser adapter module") |> Zoi.optional(),
+        pool: Zoi.any(description: "Optional warm session pool name") |> Zoi.optional(),
+        checkout_timeout: Zoi.integer(description: "Warm pool checkout timeout in ms") |> Zoi.optional()
+      })
 
   alias Jido.Browser.Error
 

--- a/lib/jido_browser/actions/switch_tab.ex
+++ b/lib/jido_browser/actions/switch_tab.ex
@@ -3,16 +3,17 @@ defmodule Jido.Browser.Actions.SwitchTab do
   Jido Action for switching to a specific browser tab.
   """
 
-  use Jido.Action,
+  use Jido.Browser.Action,
     name: "browser_switch_tab",
     description: "Switch to another browser tab",
     category: "Browser",
     tags: ["browser", "tabs", "navigation"],
     vsn: "2.0.0",
-    schema: [
-      index: [type: :integer, required: true, doc: "Tab index to activate"],
-      timeout: [type: :integer, doc: "Timeout in milliseconds"]
-    ]
+    schema:
+      Zoi.object(%{
+        index: Zoi.integer(description: "Tab index to activate"),
+        timeout: Zoi.integer(description: "Timeout in milliseconds") |> Zoi.optional()
+      })
 
   alias Jido.Browser.ActionHelpers
   alias Jido.Browser.Error

--- a/lib/jido_browser/actions/type.ex
+++ b/lib/jido_browser/actions/type.ex
@@ -12,18 +12,22 @@ defmodule Jido.Browser.Actions.Type do
 
   """
 
-  use Jido.Action,
+  use Jido.Browser.Action,
     name: "browser_type",
     description: "Type text into an element in the browser",
     category: "Browser",
     tags: ["browser", "interaction", "input", "web"],
     vsn: "2.0.0",
-    schema: [
-      selector: [type: :string, required: true, doc: "CSS selector for the input element"],
-      text: [type: :string, required: true, doc: "Text to type into the element"],
-      clear: [type: :boolean, default: false, doc: "Clear the field before typing"],
-      timeout: [type: :integer, doc: "Timeout in milliseconds"]
-    ]
+    schema:
+      Zoi.object(%{
+        selector: Zoi.string(description: "CSS selector for the input element"),
+        text: Zoi.string(description: "Text to type into the element"),
+        clear:
+          Zoi.boolean(description: "Clear the field before typing")
+          |> Zoi.default(false)
+          |> Zoi.optional(),
+        timeout: Zoi.integer(description: "Timeout in milliseconds") |> Zoi.optional()
+      })
 
   alias Jido.Browser.ActionHelpers
   alias Jido.Browser.Error

--- a/lib/jido_browser/actions/wait.ex
+++ b/lib/jido_browser/actions/wait.ex
@@ -13,15 +13,13 @@ defmodule Jido.Browser.Actions.Wait do
 
   """
 
-  use Jido.Action,
+  use Jido.Browser.Action,
     name: "browser_wait",
     description: "Wait for a specified number of milliseconds",
     category: "Browser",
     tags: ["browser", "wait", "sync", "web"],
     vsn: "2.0.0",
-    schema: [
-      ms: [type: :integer, required: true, doc: "Milliseconds to wait"]
-    ]
+    schema: Zoi.object(%{ms: Zoi.integer(description: "Milliseconds to wait")})
 
   @impl true
   def run(%{ms: ms}, _context) do

--- a/lib/jido_browser/actions/wait_for_navigation.ex
+++ b/lib/jido_browser/actions/wait_for_navigation.ex
@@ -14,16 +14,20 @@ defmodule Jido.Browser.Actions.WaitForNavigation do
 
   """
 
-  use Jido.Action,
+  use Jido.Browser.Action,
     name: "browser_wait_for_navigation",
     description: "Wait for page navigation to complete",
     category: "Browser",
     tags: ["browser", "wait", "navigation", "web"],
     vsn: "2.0.0",
-    schema: [
-      url: [type: :string, doc: "URL pattern to match (substring match)"],
-      timeout: [type: :integer, default: 30_000, doc: "Maximum wait time in milliseconds"]
-    ]
+    schema:
+      Zoi.object(%{
+        url: Zoi.string(description: "URL pattern to match (substring match)") |> Zoi.optional(),
+        timeout:
+          Zoi.integer(description: "Maximum wait time in milliseconds")
+          |> Zoi.default(30_000)
+          |> Zoi.optional()
+      })
 
   alias Jido.Browser.ActionHelpers
   alias Jido.Browser.Error

--- a/lib/jido_browser/actions/wait_for_selector.ex
+++ b/lib/jido_browser/actions/wait_for_selector.ex
@@ -14,21 +14,26 @@ defmodule Jido.Browser.Actions.WaitForSelector do
 
   """
 
-  use Jido.Action,
+  use Jido.Browser.Action,
     name: "browser_wait_for_selector",
     description: "Wait for an element to appear, disappear, or change visibility state",
     category: "Browser",
     tags: ["browser", "wait", "sync", "web"],
     vsn: "2.0.0",
-    schema: [
-      selector: [type: :string, required: true, doc: "CSS selector to wait for"],
-      state: [
-        type: {:in, [:attached, :visible, :hidden, :detached]},
-        default: :visible,
-        doc: "State to wait for: :attached, :visible, :hidden, or :detached"
-      ],
-      timeout: [type: :integer, default: 30_000, doc: "Maximum wait time in milliseconds"]
-    ]
+    schema:
+      Zoi.object(%{
+        selector: Zoi.string(description: "CSS selector to wait for"),
+        state:
+          Zoi.enum([:attached, :visible, :hidden, :detached],
+            description: "State to wait for: :attached, :visible, :hidden, or :detached"
+          )
+          |> Zoi.default(:visible)
+          |> Zoi.optional(),
+        timeout:
+          Zoi.integer(description: "Maximum wait time in milliseconds")
+          |> Zoi.default(30_000)
+          |> Zoi.optional()
+      })
 
   alias Jido.Browser.ActionHelpers
   alias Jido.Browser.Error

--- a/lib/jido_browser/actions/web_fetch.ex
+++ b/lib/jido_browser/actions/web_fetch.ex
@@ -7,7 +7,7 @@ defmodule Jido.Browser.Actions.WebFetch do
   execution, including fetched PDFs and office-style documents.
   """
 
-  use Jido.Action,
+  use Jido.Browser.Action,
     name: "web_fetch",
     description:
       "Fetch a URL over HTTP(S) with domain policy controls, Extractous-backed document extraction, " <>
@@ -15,29 +15,63 @@ defmodule Jido.Browser.Actions.WebFetch do
     category: "Browser",
     tags: ["browser", "web", "fetch", "http", "retrieval"],
     vsn: "2.0.0",
-    schema: [
-      url: [type: :string, required: true, doc: "The URL to fetch"],
-      format: [type: {:in, [:markdown, :text, :html]}, default: :markdown, doc: "Output format"],
-      backend: [type: {:in, [:req, :browsey]}, doc: "HTTP backend used for the fetch"],
-      selector: [type: :string, doc: "Optional CSS selector for HTML pages"],
-      allowed_domains: [type: {:list, :string}, default: [], doc: "Allow-list of host or host/path rules"],
-      blocked_domains: [type: {:list, :string}, default: [], doc: "Block-list of host or host/path rules"],
-      allow_private_network: [type: :boolean, default: false, doc: "Allow private network destinations"],
-      focus_terms: [type: {:list, :string}, default: [], doc: "Terms used to filter the fetched document"],
-      focus_window: [type: :integer, default: 0, doc: "Paragraph window around each focus match"],
-      max_content_tokens: [type: :integer, doc: "Approximate token cap for returned content"],
-      max_response_bytes: [
-        type: :timeout,
-        default: 5 * 1024 * 1024,
-        doc: "Positive response byte cap, or infinity to disable the cap"
-      ],
-      citations: [type: :boolean, default: false, doc: "Include citation-ready passage offsets"],
-      cache: [type: :boolean, default: true, doc: "Reuse cached fetch results when available"],
-      timeout: [type: :integer, doc: "Receive timeout in milliseconds"],
-      require_known_url: [type: :boolean, default: false, doc: "Require the URL to already be present in tool context"],
-      known_urls: [type: {:list, :string}, default: [], doc: "Additional known URLs accepted for provenance checks"],
-      max_uses: [type: :integer, doc: "Maximum successful web fetch calls allowed in current skill state"]
-    ]
+    schema:
+      Zoi.object(%{
+        url: Zoi.string(description: "The URL to fetch"),
+        format:
+          Zoi.enum([:markdown, :text, :html], description: "Output format")
+          |> Zoi.default(:markdown)
+          |> Zoi.optional(),
+        backend: Zoi.enum([:req, :browsey], description: "HTTP backend used for the fetch") |> Zoi.optional(),
+        selector: Zoi.string(description: "Optional CSS selector for HTML pages") |> Zoi.optional(),
+        allowed_domains:
+          Zoi.list(Zoi.string(), description: "Allow-list of host or host/path rules")
+          |> Zoi.default([])
+          |> Zoi.optional(),
+        blocked_domains:
+          Zoi.list(Zoi.string(), description: "Block-list of host or host/path rules")
+          |> Zoi.default([])
+          |> Zoi.optional(),
+        allow_private_network:
+          Zoi.boolean(description: "Allow private network destinations")
+          |> Zoi.default(false)
+          |> Zoi.optional(),
+        focus_terms:
+          Zoi.list(Zoi.string(), description: "Terms used to filter the fetched document")
+          |> Zoi.default([])
+          |> Zoi.optional(),
+        focus_window:
+          Zoi.integer(description: "Paragraph window around each focus match")
+          |> Zoi.default(0)
+          |> Zoi.optional(),
+        max_content_tokens: Zoi.integer(description: "Approximate token cap for returned content") |> Zoi.optional(),
+        max_response_bytes:
+          Zoi.union([Zoi.integer() |> Zoi.min(0), Zoi.literal(:infinity)],
+            description: "Positive response byte cap, or infinity to disable the cap"
+          )
+          |> Zoi.default(5 * 1024 * 1024)
+          |> Zoi.optional(),
+        citations:
+          Zoi.boolean(description: "Include citation-ready passage offsets")
+          |> Zoi.default(false)
+          |> Zoi.optional(),
+        cache:
+          Zoi.boolean(description: "Reuse cached fetch results when available")
+          |> Zoi.default(true)
+          |> Zoi.optional(),
+        timeout: Zoi.integer(description: "Receive timeout in milliseconds") |> Zoi.optional(),
+        require_known_url:
+          Zoi.boolean(description: "Require the URL to already be present in tool context")
+          |> Zoi.default(false)
+          |> Zoi.optional(),
+        known_urls:
+          Zoi.list(Zoi.string(), description: "Additional known URLs accepted for provenance checks")
+          |> Zoi.default([])
+          |> Zoi.optional(),
+        max_uses:
+          Zoi.integer(description: "Maximum successful web fetch calls allowed in current skill state")
+          |> Zoi.optional()
+      })
 
   alias Jido.Browser.Error
 

--- a/lib/jido_browser/zoi_json_schema.ex
+++ b/lib/jido_browser/zoi_json_schema.ex
@@ -1,0 +1,5 @@
+defimpl Zoi.JSONSchema.Encoder, for: Zoi.Types.Atom do
+  @moduledoc false
+
+  def encode(_schema), do: %{type: :string}
+end

--- a/test/jido_browser/action_contract_content_composite_test.exs
+++ b/test/jido_browser/action_contract_content_composite_test.exs
@@ -344,17 +344,20 @@ defmodule Jido.Browser.ActionContractContentCompositeTest do
       |> Kernel.++(@contracts)
       |> Enum.map(& &1.module)
 
-    production_modules =
-      :jido_browser
-      |> Application.spec(:modules)
-      |> Enum.filter(fn module ->
-        String.starts_with?(Atom.to_string(module), "Elixir.Jido.Browser.Actions.") and
-          Code.ensure_loaded?(module) and function_exported?(module, :__action_metadata__, 0)
-      end)
+    production_modules = production_actions()
 
     assert length(contract_modules) == 40
     assert length(Enum.uniq(contract_modules)) == 40
     assert MapSet.new(contract_modules) == MapSet.new(production_modules)
+  end
+
+  test "uses static Zoi object input schemas for every production action" do
+    for action <- production_actions() do
+      assert %Zoi.Types.Map{fields: fields} = schema = action.schema()
+      assert is_list(fields)
+      refute schema_contains?(schema, &is_function/1)
+      refute schema_contains?(schema, &match?(%Zoi.Types.Lazy{}, &1))
+    end
   end
 
   test "web retrieval actions convert the tool infinity value before validation" do
@@ -403,4 +406,37 @@ defmodule Jido.Browser.ActionContractContentCompositeTest do
     assert %{"error" => error_message} = Jason.decode!(error_json)
     assert error_message =~ "required :required_count option not found"
   end
+
+  defp production_actions do
+    :jido_browser
+    |> Application.spec(:modules)
+    |> Enum.filter(fn module ->
+      String.starts_with?(Atom.to_string(module), "Elixir.Jido.Browser.Actions.") and
+        Code.ensure_loaded?(module) and function_exported?(module, :__action_metadata__, 0)
+    end)
+  end
+
+  defp schema_contains?(value, predicate) do
+    predicate.(value) or schema_children_contain?(value, predicate)
+  end
+
+  defp schema_children_contain?(value, predicate) when is_map(value) do
+    value
+    |> Map.to_list()
+    |> Enum.any?(fn {key, child} ->
+      schema_contains?(key, predicate) or schema_contains?(child, predicate)
+    end)
+  end
+
+  defp schema_children_contain?(value, predicate) when is_list(value) do
+    Enum.any?(value, &schema_contains?(&1, predicate))
+  end
+
+  defp schema_children_contain?(value, predicate) when is_tuple(value) do
+    value
+    |> Tuple.to_list()
+    |> Enum.any?(&schema_contains?(&1, predicate))
+  end
+
+  defp schema_children_contain?(_value, _predicate), do: false
 end

--- a/test/support/action_contract_assertions.ex
+++ b/test/support/action_contract_assertions.ex
@@ -3,13 +3,14 @@ defmodule Jido.Browser.ActionContractAssertions do
 
   import ExUnit.Assertions
 
+  alias Jido.Action.Schema
   alias Jido.Action.Tool
 
   @unknown_atom :contract_unknown_atom
   @unknown_string "contract_unknown_string"
 
   def assert_contract(%{module: action, name: name, description: description, schema: schema}) do
-    assert normalized_schema(action.schema()) == normalized_schema(schema)
+    assert Schema.schema_type(action.schema()) == :zoi
 
     assert_validation_contract(action, schema)
     assert_tool_input_contract(action, schema)
@@ -104,6 +105,7 @@ defmodule Jido.Browser.ActionContractAssertions do
           options.type
           |> json_type()
           |> Map.put("description", options.doc)
+          |> maybe_put_default(options)
 
         {Atom.to_string(key), property}
       end)
@@ -115,6 +117,7 @@ defmodule Jido.Browser.ActionContractAssertions do
       |> Enum.sort()
 
     %{
+      "$schema" => "https://json-schema.org/draft/2020-12/schema",
       "additionalProperties" => false,
       "properties" => properties,
       "required" => required,
@@ -133,15 +136,15 @@ defmodule Jido.Browser.ActionContractAssertions do
 
   defp json_type(:timeout) do
     %{
-      "oneOf" => [
+      "anyOf" => [
         %{"minimum" => 0, "type" => "integer"},
-        %{"enum" => ["infinity"], "type" => "string"}
+        %{"const" => "infinity"}
       ]
     }
   end
 
   defp json_type(:atom), do: %{"type" => "string"}
-  defp json_type(:any), do: %{"type" => "string"}
+  defp json_type(:any), do: %{}
 
   defp json_type({:list, subtype}) do
     %{"items" => json_type(subtype), "type" => "array"}
@@ -165,6 +168,9 @@ defmodule Jido.Browser.ActionContractAssertions do
 
   defp enum_json_value(value) when is_atom(value), do: Atom.to_string(value)
   defp enum_json_value(value), do: value
+
+  defp maybe_put_default(property, %{default: default}), do: Map.put(property, "default", default)
+  defp maybe_put_default(property, _options), do: property
 
   defp sample_params(schema) do
     Map.new(schema, fn {key, options} -> {key, sample_value(options.type, key)} end)
@@ -208,28 +214,21 @@ defmodule Jido.Browser.ActionContractAssertions do
   defp alternate_sample_value({:list, subtype}, key), do: [alternate_sample_value(subtype, key)]
   defp alternate_sample_value({:in, values}, _key), do: List.last(values)
 
-  defp normalized_schema(schema) do
-    Map.new(schema, fn {key, options} ->
-      normalized_options =
-        options
-        |> Map.new()
-        |> Map.update(:type, nil, &normalize_type/1)
-
-      {key, normalized_options}
-    end)
+  defp normalize_json_schema(schema) do
+    schema
+    |> Jason.encode!()
+    |> Jason.decode!()
+    |> sort_json_schema()
   end
 
-  defp normalize_type({:in, values}), do: {:in, Enum.sort(values)}
-  defp normalize_type(type), do: type
-
-  defp normalize_json_schema(schema) when is_map(schema) do
+  defp sort_json_schema(schema) when is_map(schema) do
     Map.new(schema, fn
       {"enum", values} -> {"enum", Enum.sort(values)}
       {"required", values} -> {"required", Enum.sort(values)}
-      {key, value} -> {key, normalize_json_schema(value)}
+      {key, value} -> {key, sort_json_schema(value)}
     end)
   end
 
-  defp normalize_json_schema(values) when is_list(values), do: Enum.map(values, &normalize_json_schema/1)
-  defp normalize_json_schema(value), do: value
+  defp sort_json_schema(values) when is_list(values), do: Enum.map(values, &sort_json_schema/1)
+  defp sort_json_schema(value), do: value
 end


### PR DESCRIPTION
Closes #76

## Summary

- convert all 40 production action input schemas from NimbleOptions keyword lists to static `Zoi.object/2` values
- keep required fields, optional fields, defaults, enums, descriptions, unknown keys, and tool string-key conversion behavior
- add a browser-owned Action wrapper that applies optional Zoi defaults after validation
- add deterministic JSON Schema encoding for Zoi atom fields
- enforce that every production schema is a static Zoi object with no functions or lazy schemas

## Intentional contract differences

- `schema/0` now returns a `Zoi.Types.Map` value instead of a NimbleOptions keyword list
- generated JSON Schema now includes the Zoi draft URI and property default annotations
- `:any` fields are represented as unconstrained JSON values instead of strings
- the timeout union uses `anyOf` with an `infinity` constant instead of the prior `oneOf` enum form
- validation error text and detail structure now come from Zoi

Runtime defaults and required-field behavior remain unchanged.

## Verification

- `mix format --check-formatted`
- `mix compile --warnings-as-errors`
- `mix test` — 412 passed, 26 excluded
- focused action contract suite — 45 passed
