### PR TITLE
refactor!: move browser action metadata into the browser registry

### DIFF
--- a/lib/jido_browser/action_registry.ex
+++ b/lib/jido_browser/action_registry.ex
@@ -1,0 +1,156 @@
+defmodule Jido.Browser.ActionRegistry.Entry do
+  @moduledoc "Metadata for one browser action."
+
+  @enforce_keys [
+    :action,
+    :signal_name,
+    :category,
+    :tags,
+    :support_level,
+    :tool_contract_version
+  ]
+  defstruct @enforce_keys
+
+  @type t :: %__MODULE__{
+          action: module(),
+          signal_name: String.t(),
+          category: atom(),
+          tags: [String.t()],
+          support_level: atom(),
+          tool_contract_version: pos_integer()
+        }
+end
+
+defmodule Jido.Browser.ActionRegistry do
+  @moduledoc """
+  Browser-owned metadata and stable ordering for the Jido Browser tool set.
+
+  Action modules own execution and schemas. This registry owns discovery
+  metadata that is specific to the browser tool catalog.
+  """
+
+  alias Jido.Browser.ActionRegistry.Entry
+
+  @tool_contract_version 3
+  @support_level :supported
+
+  @entry_specs [
+    # Session lifecycle
+    {Jido.Browser.Actions.StartSession, "browser.start_session", :session, ["browser", "session", "lifecycle"]},
+    {Jido.Browser.Actions.EndSession, "browser.end_session", :session, ["browser", "session", "lifecycle"]},
+    {Jido.Browser.Actions.GetStatus, "browser.get_status", :session, ["browser", "session", "status"]},
+    {Jido.Browser.Actions.PoolStatus, "browser.pool_status", :session, ["browser", "pool", "status", "diagnostics"]},
+    {Jido.Browser.Actions.SaveState, "browser.save_state", :session, ["browser", "state", "session"]},
+    {Jido.Browser.Actions.LoadState, "browser.load_state", :session, ["browser", "state", "session"]},
+    # Navigation
+    {Jido.Browser.Actions.Navigate, "browser.navigate", :navigation, ["browser", "navigation", "web"]},
+    {Jido.Browser.Actions.Back, "browser.back", :navigation, ["browser", "navigation", "history", "web"]},
+    {Jido.Browser.Actions.Forward, "browser.forward", :navigation, ["browser", "navigation", "history", "web"]},
+    {Jido.Browser.Actions.Reload, "browser.reload", :navigation, ["browser", "navigation", "web"]},
+    {Jido.Browser.Actions.GetUrl, "browser.get_url", :navigation, ["browser", "navigation", "web"]},
+    {Jido.Browser.Actions.GetTitle, "browser.get_title", :navigation, ["browser", "navigation", "web"]},
+    # Interaction
+    {Jido.Browser.Actions.Click, "browser.click", :interaction, ["browser", "interaction", "web"]},
+    {Jido.Browser.Actions.Type, "browser.type", :interaction, ["browser", "interaction", "input", "web"]},
+    {Jido.Browser.Actions.Hover, "browser.hover", :interaction, ["browser", "interaction", "hover", "web"]},
+    {Jido.Browser.Actions.Focus, "browser.focus", :interaction, ["browser", "interaction", "focus", "web"]},
+    {Jido.Browser.Actions.Scroll, "browser.scroll", :interaction, ["browser", "interaction", "scroll", "web"]},
+    {Jido.Browser.Actions.SelectOption, "browser.select_option", :interaction,
+     ["browser", "interaction", "select", "form", "web"]},
+    # Waiting and synchronization
+    {Jido.Browser.Actions.Wait, "browser.wait", :synchronization, ["browser", "wait", "sync", "web"]},
+    {Jido.Browser.Actions.WaitForSelector, "browser.wait_for_selector", :synchronization,
+     ["browser", "wait", "sync", "web"]},
+    {Jido.Browser.Actions.WaitForNavigation, "browser.wait_for_navigation", :synchronization,
+     ["browser", "wait", "navigation", "web"]},
+    # Element queries
+    {Jido.Browser.Actions.Query, "browser.query", :query, ["browser", "query", "web"]},
+    {Jido.Browser.Actions.GetText, "browser.get_text", :query, ["browser", "query", "web"]},
+    {Jido.Browser.Actions.GetAttribute, "browser.get_attribute", :query, ["browser", "query", "web"]},
+    {Jido.Browser.Actions.IsVisible, "browser.is_visible", :query, ["browser", "query", "web"]},
+    # Tabs
+    {Jido.Browser.Actions.ListTabs, "browser.tab_list", :tabs, ["browser", "tabs", "session"]},
+    {Jido.Browser.Actions.NewTab, "browser.tab_new", :tabs, ["browser", "tabs", "navigation"]},
+    {Jido.Browser.Actions.SwitchTab, "browser.tab_switch", :tabs, ["browser", "tabs", "navigation"]},
+    {Jido.Browser.Actions.CloseTab, "browser.tab_close", :tabs, ["browser", "tabs", "session"]},
+    # Content extraction
+    {Jido.Browser.Actions.Snapshot, "browser.snapshot", :content,
+     ["browser", "snapshot", "observe", "page", "web", "ai"]},
+    {Jido.Browser.Actions.Screenshot, "browser.screenshot", :content, ["browser", "screenshot", "capture", "web"]},
+    {Jido.Browser.Actions.ExtractContent, "browser.extract", :content,
+     ["browser", "content", "extract", "markdown", "web"]},
+    # Diagnostics
+    {Jido.Browser.Actions.Console, "browser.console", :diagnostics, ["browser", "diagnostics", "console"]},
+    {Jido.Browser.Actions.Errors, "browser.errors", :diagnostics, ["browser", "diagnostics", "errors"]},
+    # Advanced
+    {Jido.Browser.Actions.Evaluate, "browser.evaluate", :advanced, ["browser", "javascript", "evaluate", "web"]},
+    # Self-contained composite actions
+    {Jido.Browser.Actions.ReadPage, "browser.read_page", :composite, ["browser", "web", "read", "content", "markdown"]},
+    {Jido.Browser.Actions.SnapshotUrl, "browser.snapshot_url", :composite,
+     ["browser", "web", "snapshot", "observe", "ai"]},
+    {Jido.Browser.Actions.SearchWeb, "browser.search_web", :composite, ["browser", "web", "search", "brave"]},
+    {Jido.Browser.Actions.WebFetch, "browser.web_fetch", :composite, ["browser", "web", "fetch", "http", "retrieval"]},
+    {Jido.Browser.Actions.FetchRich, "browser.fetch_rich", :composite,
+     ["browser", "web", "fetch", "retrieval", "agent"]}
+  ]
+
+  @entries Enum.map(@entry_specs, fn {action, signal_name, category, tags} ->
+             %Entry{
+               action: action,
+               signal_name: signal_name,
+               category: category,
+               tags: tags,
+               support_level: @support_level,
+               tool_contract_version: @tool_contract_version
+             }
+           end)
+
+  for %Entry{action: action} <- @entries do
+    Code.ensure_compiled!(action)
+  end
+
+  @doc "Returns all registry entries in stable tool order."
+  @spec entries() :: [Entry.t()]
+  def entries, do: @entries
+
+  @doc "Returns all action modules in stable tool order."
+  @spec actions() :: [module()]
+  def actions, do: Enum.map(@entries, & &1.action)
+
+  @doc "Returns all signal routes in stable tool order."
+  @spec signal_routes() :: [{String.t(), module()}]
+  def signal_routes, do: Enum.map(@entries, &{&1.signal_name, &1.action})
+
+  @doc "Returns all signal names in stable tool order."
+  @spec signal_patterns() :: [String.t()]
+  def signal_patterns, do: Enum.map(@entries, & &1.signal_name)
+
+  @doc "Returns the browser tool contract major version."
+  @spec tool_contract_version() :: pos_integer()
+  def tool_contract_version, do: @tool_contract_version
+
+  @doc "Finds metadata by action module or signal name."
+  @spec fetch(module() | String.t()) :: {:ok, Entry.t()} | :error
+  def fetch(action_or_signal) do
+    case Enum.find(@entries, &entry_matches?(&1, action_or_signal)) do
+      nil -> :error
+      entry -> {:ok, entry}
+    end
+  end
+
+  @doc "Returns entries in one functional category."
+  @spec by_category(atom()) :: [Entry.t()]
+  def by_category(category), do: Enum.filter(@entries, &(&1.category == category))
+
+  @doc "Returns entries that contain the specified tag."
+  @spec with_tag(String.t()) :: [Entry.t()]
+  def with_tag(tag), do: Enum.filter(@entries, &(tag in &1.tags))
+
+  @doc "Returns entries at the specified support level."
+  @spec by_support_level(atom()) :: [Entry.t()]
+  def by_support_level(level), do: Enum.filter(@entries, &(&1.support_level == level))
+
+  defp entry_matches?(%Entry{action: action}, action), do: true
+  defp entry_matches?(%Entry{signal_name: signal_name}, signal_name), do: true
+  defp entry_matches?(_entry, _key), do: false
+end

--- a/lib/jido_browser/actions/back.ex
+++ b/lib/jido_browser/actions/back.ex
@@ -15,9 +15,6 @@ defmodule Jido.Browser.Actions.Back do
   use Jido.Browser.Action,
     name: "browser_back",
     description: "Navigate back in browser history",
-    category: "Browser",
-    tags: ["browser", "navigation", "history", "web"],
-    vsn: "2.0.0",
     schema: Zoi.object(%{timeout: Zoi.integer(description: "Timeout in milliseconds") |> Zoi.optional()})
 
   alias Jido.Browser.ActionHelpers

--- a/lib/jido_browser/actions/click.ex
+++ b/lib/jido_browser/actions/click.ex
@@ -16,9 +16,6 @@ defmodule Jido.Browser.Actions.Click do
   use Jido.Browser.Action,
     name: "browser_click",
     description: "Click an element in the browser",
-    category: "Browser",
-    tags: ["browser", "interaction", "web"],
-    vsn: "2.0.0",
     schema:
       Zoi.object(%{
         selector: Zoi.string(description: "CSS selector for the element to click"),

--- a/lib/jido_browser/actions/close_tab.ex
+++ b/lib/jido_browser/actions/close_tab.ex
@@ -6,9 +6,6 @@ defmodule Jido.Browser.Actions.CloseTab do
   use Jido.Browser.Action,
     name: "browser_close_tab",
     description: "Close a browser tab",
-    category: "Browser",
-    tags: ["browser", "tabs", "session"],
-    vsn: "2.0.0",
     schema:
       Zoi.object(%{
         index: Zoi.integer(description: "Optional tab index to close") |> Zoi.optional(),

--- a/lib/jido_browser/actions/console.ex
+++ b/lib/jido_browser/actions/console.ex
@@ -6,9 +6,6 @@ defmodule Jido.Browser.Actions.Console do
   use Jido.Browser.Action,
     name: "browser_console",
     description: "Read browser console messages",
-    category: "Browser",
-    tags: ["browser", "diagnostics", "console"],
-    vsn: "2.0.0",
     schema: Zoi.object(%{timeout: Zoi.integer(description: "Timeout in milliseconds") |> Zoi.optional()})
 
   alias Jido.Browser.ActionHelpers

--- a/lib/jido_browser/actions/end_session.ex
+++ b/lib/jido_browser/actions/end_session.ex
@@ -16,9 +16,6 @@ defmodule Jido.Browser.Actions.EndSession do
   use Jido.Browser.Action,
     name: "browser_end_session",
     description: "End the current browser session",
-    category: "Browser",
-    tags: ["browser", "session", "lifecycle"],
-    vsn: "2.0.0",
     schema: Zoi.object(%{})
 
   alias Jido.Browser.ActionHelpers

--- a/lib/jido_browser/actions/errors.ex
+++ b/lib/jido_browser/actions/errors.ex
@@ -6,9 +6,6 @@ defmodule Jido.Browser.Actions.Errors do
   use Jido.Browser.Action,
     name: "browser_errors",
     description: "Read browser runtime errors",
-    category: "Browser",
-    tags: ["browser", "diagnostics", "errors"],
-    vsn: "2.0.0",
     schema: Zoi.object(%{timeout: Zoi.integer(description: "Timeout in milliseconds") |> Zoi.optional()})
 
   alias Jido.Browser.ActionHelpers

--- a/lib/jido_browser/actions/evaluate.ex
+++ b/lib/jido_browser/actions/evaluate.ex
@@ -16,9 +16,6 @@ defmodule Jido.Browser.Actions.Evaluate do
   use Jido.Browser.Action,
     name: "browser_evaluate",
     description: "Execute JavaScript in the browser and return the result",
-    category: "Browser",
-    tags: ["browser", "javascript", "evaluate", "web"],
-    vsn: "2.0.0",
     schema:
       Zoi.object(%{
         script: Zoi.string(description: "JavaScript code to execute"),

--- a/lib/jido_browser/actions/extract_content.ex
+++ b/lib/jido_browser/actions/extract_content.ex
@@ -21,9 +21,6 @@ defmodule Jido.Browser.Actions.ExtractContent do
   use Jido.Browser.Action,
     name: "browser_extract_content",
     description: "Extract content from the current page as markdown, HTML, or text",
-    category: "Browser",
-    tags: ["browser", "content", "extract", "markdown", "web"],
-    vsn: "2.0.0",
     schema:
       Zoi.object(%{
         selector:

--- a/lib/jido_browser/actions/fetch_rich.ex
+++ b/lib/jido_browser/actions/fetch_rich.ex
@@ -7,9 +7,6 @@ defmodule Jido.Browser.Actions.FetchRich do
     name: "fetch_rich",
     description:
       "Fetch a URL with normalized rich content, using fast HTTP retrieval first and optional browser fallback.",
-    category: "Browser",
-    tags: ["browser", "web", "fetch", "retrieval", "agent"],
-    vsn: "2.0.0",
     schema:
       Zoi.object(%{
         url: Zoi.string(description: "The URL to fetch"),

--- a/lib/jido_browser/actions/focus.ex
+++ b/lib/jido_browser/actions/focus.ex
@@ -16,9 +16,6 @@ defmodule Jido.Browser.Actions.Focus do
   use Jido.Browser.Action,
     name: "browser_focus",
     description: "Focus on an element in the browser",
-    category: "Browser",
-    tags: ["browser", "interaction", "focus", "web"],
-    vsn: "2.0.0",
     schema:
       Zoi.object(%{
         selector: Zoi.string(description: "CSS selector for the element to focus"),

--- a/lib/jido_browser/actions/forward.ex
+++ b/lib/jido_browser/actions/forward.ex
@@ -15,9 +15,6 @@ defmodule Jido.Browser.Actions.Forward do
   use Jido.Browser.Action,
     name: "browser_forward",
     description: "Navigate forward in browser history",
-    category: "Browser",
-    tags: ["browser", "navigation", "history", "web"],
-    vsn: "2.0.0",
     schema: Zoi.object(%{timeout: Zoi.integer(description: "Timeout in milliseconds") |> Zoi.optional()})
 
   alias Jido.Browser.ActionHelpers

--- a/lib/jido_browser/actions/get_attribute.ex
+++ b/lib/jido_browser/actions/get_attribute.ex
@@ -16,9 +16,6 @@ defmodule Jido.Browser.Actions.GetAttribute do
   use Jido.Browser.Action,
     name: "browser_get_attribute",
     description: "Get an attribute value from an element",
-    category: "Browser",
-    tags: ["browser", "query", "web"],
-    vsn: "2.0.0",
     schema:
       Zoi.object(%{
         selector: Zoi.string(description: "CSS selector for the element"),

--- a/lib/jido_browser/actions/get_status.ex
+++ b/lib/jido_browser/actions/get_status.ex
@@ -17,9 +17,6 @@ defmodule Jido.Browser.Actions.GetStatus do
   use Jido.Browser.Action,
     name: "browser_get_status",
     description: "Get current session status (url, title, is_alive)",
-    category: "Browser",
-    tags: ["browser", "session", "status"],
-    vsn: "2.0.0",
     schema: Zoi.object(%{})
 
   alias Jido.Browser.ActionHelpers

--- a/lib/jido_browser/actions/get_text.ex
+++ b/lib/jido_browser/actions/get_text.ex
@@ -16,9 +16,6 @@ defmodule Jido.Browser.Actions.GetText do
   use Jido.Browser.Action,
     name: "browser_get_text",
     description: "Get text content of an element",
-    category: "Browser",
-    tags: ["browser", "query", "web"],
-    vsn: "2.0.0",
     schema:
       Zoi.object(%{
         selector: Zoi.string(description: "CSS selector for the element"),

--- a/lib/jido_browser/actions/get_title.ex
+++ b/lib/jido_browser/actions/get_title.ex
@@ -15,9 +15,6 @@ defmodule Jido.Browser.Actions.GetTitle do
   use Jido.Browser.Action,
     name: "browser_get_title",
     description: "Get the current page title",
-    category: "Browser",
-    tags: ["browser", "navigation", "web"],
-    vsn: "2.0.0",
     schema: Zoi.object(%{timeout: Zoi.integer(description: "Timeout in milliseconds") |> Zoi.optional()})
 
   alias Jido.Browser.ActionHelpers

--- a/lib/jido_browser/actions/get_url.ex
+++ b/lib/jido_browser/actions/get_url.ex
@@ -15,9 +15,6 @@ defmodule Jido.Browser.Actions.GetUrl do
   use Jido.Browser.Action,
     name: "browser_get_url",
     description: "Get the current page URL",
-    category: "Browser",
-    tags: ["browser", "navigation", "web"],
-    vsn: "2.0.0",
     schema: Zoi.object(%{timeout: Zoi.integer(description: "Timeout in milliseconds") |> Zoi.optional()})
 
   alias Jido.Browser.ActionHelpers

--- a/lib/jido_browser/actions/hover.ex
+++ b/lib/jido_browser/actions/hover.ex
@@ -16,9 +16,6 @@ defmodule Jido.Browser.Actions.Hover do
   use Jido.Browser.Action,
     name: "browser_hover",
     description: "Hover over an element in the browser",
-    category: "Browser",
-    tags: ["browser", "interaction", "hover", "web"],
-    vsn: "2.0.0",
     schema:
       Zoi.object(%{
         selector: Zoi.string(description: "CSS selector for the element to hover"),

--- a/lib/jido_browser/actions/is_visible.ex
+++ b/lib/jido_browser/actions/is_visible.ex
@@ -16,9 +16,6 @@ defmodule Jido.Browser.Actions.IsVisible do
   use Jido.Browser.Action,
     name: "browser_is_visible",
     description: "Check if an element is visible",
-    category: "Browser",
-    tags: ["browser", "query", "web"],
-    vsn: "2.0.0",
     schema: Zoi.object(%{selector: Zoi.string(description: "CSS selector for the element")})
 
   alias Jido.Browser.ActionHelpers

--- a/lib/jido_browser/actions/list_tabs.ex
+++ b/lib/jido_browser/actions/list_tabs.ex
@@ -6,9 +6,6 @@ defmodule Jido.Browser.Actions.ListTabs do
   use Jido.Browser.Action,
     name: "browser_list_tabs",
     description: "List open browser tabs",
-    category: "Browser",
-    tags: ["browser", "tabs", "session"],
-    vsn: "2.0.0",
     schema: Zoi.object(%{timeout: Zoi.integer(description: "Timeout in milliseconds") |> Zoi.optional()})
 
   alias Jido.Browser.ActionHelpers

--- a/lib/jido_browser/actions/load_state.ex
+++ b/lib/jido_browser/actions/load_state.ex
@@ -6,9 +6,6 @@ defmodule Jido.Browser.Actions.LoadState do
   use Jido.Browser.Action,
     name: "browser_load_state",
     description: "Load browser session state from a file",
-    category: "Browser",
-    tags: ["browser", "state", "session"],
-    vsn: "2.0.0",
     schema:
       Zoi.object(%{
         path: Zoi.string(description: "Filesystem path of the saved session state"),

--- a/lib/jido_browser/actions/navigate.ex
+++ b/lib/jido_browser/actions/navigate.ex
@@ -15,9 +15,6 @@ defmodule Jido.Browser.Actions.Navigate do
   use Jido.Browser.Action,
     name: "browser_navigate",
     description: "Navigate the browser to a URL",
-    category: "Browser",
-    tags: ["browser", "navigation", "web"],
-    vsn: "2.0.0",
     schema:
       Zoi.object(%{
         url: Zoi.string(description: "The URL to navigate to"),

--- a/lib/jido_browser/actions/new_tab.ex
+++ b/lib/jido_browser/actions/new_tab.ex
@@ -6,9 +6,6 @@ defmodule Jido.Browser.Actions.NewTab do
   use Jido.Browser.Action,
     name: "browser_new_tab",
     description: "Open a new browser tab",
-    category: "Browser",
-    tags: ["browser", "tabs", "navigation"],
-    vsn: "2.0.0",
     schema:
       Zoi.object(%{
         url: Zoi.string(description: "Optional URL to open in the new tab") |> Zoi.optional(),

--- a/lib/jido_browser/actions/pool_status.ex
+++ b/lib/jido_browser/actions/pool_status.ex
@@ -6,9 +6,6 @@ defmodule Jido.Browser.Actions.PoolStatus do
   use Jido.Browser.Action,
     name: "browser_pool_status",
     description: "Return readiness and lifecycle status for a warm browser pool.",
-    category: "Browser",
-    tags: ["browser", "pool", "status", "diagnostics"],
-    vsn: "2.0.0",
     schema:
       Zoi.object(%{
         pool:

--- a/lib/jido_browser/actions/query.ex
+++ b/lib/jido_browser/actions/query.ex
@@ -16,9 +16,6 @@ defmodule Jido.Browser.Actions.Query do
   use Jido.Browser.Action,
     name: "browser_query",
     description: "Query for elements matching a CSS selector",
-    category: "Browser",
-    tags: ["browser", "query", "web"],
-    vsn: "2.0.0",
     schema:
       Zoi.object(%{
         selector: Zoi.string(description: "CSS selector to query"),

--- a/lib/jido_browser/actions/read_page.ex
+++ b/lib/jido_browser/actions/read_page.ex
@@ -20,9 +20,6 @@ defmodule Jido.Browser.Actions.ReadPage do
     description:
       "Read a web page and return its content as markdown, text, or HTML. " <>
         "Manages browser session automatically.",
-    category: "Browser",
-    tags: ["browser", "web", "read", "content", "markdown"],
-    vsn: "2.0.0",
     schema:
       Zoi.object(%{
         url: Zoi.string(description: "The URL to read"),

--- a/lib/jido_browser/actions/reload.ex
+++ b/lib/jido_browser/actions/reload.ex
@@ -15,9 +15,6 @@ defmodule Jido.Browser.Actions.Reload do
   use Jido.Browser.Action,
     name: "browser_reload",
     description: "Reload the current page",
-    category: "Browser",
-    tags: ["browser", "navigation", "web"],
-    vsn: "2.0.0",
     schema: Zoi.object(%{timeout: Zoi.integer(description: "Timeout in milliseconds") |> Zoi.optional()})
 
   alias Jido.Browser.ActionHelpers

--- a/lib/jido_browser/actions/save_state.ex
+++ b/lib/jido_browser/actions/save_state.ex
@@ -6,9 +6,6 @@ defmodule Jido.Browser.Actions.SaveState do
   use Jido.Browser.Action,
     name: "browser_save_state",
     description: "Save browser session state to a file",
-    category: "Browser",
-    tags: ["browser", "state", "session"],
-    vsn: "2.0.0",
     schema:
       Zoi.object(%{
         path: Zoi.string(description: "Filesystem path where session state will be stored"),

--- a/lib/jido_browser/actions/screenshot.ex
+++ b/lib/jido_browser/actions/screenshot.ex
@@ -16,9 +16,6 @@ defmodule Jido.Browser.Actions.Screenshot do
   use Jido.Browser.Action,
     name: "browser_screenshot",
     description: "Take a screenshot of the current page",
-    category: "Browser",
-    tags: ["browser", "screenshot", "capture", "web"],
-    vsn: "2.0.0",
     schema:
       Zoi.object(%{
         full_page:

--- a/lib/jido_browser/actions/scroll.ex
+++ b/lib/jido_browser/actions/scroll.ex
@@ -18,9 +18,6 @@ defmodule Jido.Browser.Actions.Scroll do
   use Jido.Browser.Action,
     name: "browser_scroll",
     description: "Scroll the page by pixels, to preset positions, or to an element",
-    category: "Browser",
-    tags: ["browser", "interaction", "scroll", "web"],
-    vsn: "2.0.0",
     schema:
       Zoi.object(%{
         x: Zoi.integer(description: "Horizontal scroll pixels") |> Zoi.optional(),

--- a/lib/jido_browser/actions/search_web.ex
+++ b/lib/jido_browser/actions/search_web.ex
@@ -23,9 +23,6 @@ defmodule Jido.Browser.Actions.SearchWeb do
     description:
       "Search the web using Brave Search API and return structured results " <>
         "with titles, URLs, and snippets.",
-    category: "Browser",
-    tags: ["browser", "web", "search", "brave"],
-    vsn: "2.0.0",
     schema:
       Zoi.object(%{
         query: Zoi.string(description: "Search query"),

--- a/lib/jido_browser/actions/select_option.ex
+++ b/lib/jido_browser/actions/select_option.ex
@@ -17,9 +17,6 @@ defmodule Jido.Browser.Actions.SelectOption do
   use Jido.Browser.Action,
     name: "browser_select_option",
     description: "Select an option from a dropdown element",
-    category: "Browser",
-    tags: ["browser", "interaction", "select", "form", "web"],
-    vsn: "2.0.0",
     schema:
       Zoi.object(%{
         selector: Zoi.string(description: "CSS selector for the select element"),

--- a/lib/jido_browser/actions/snapshot.ex
+++ b/lib/jido_browser/actions/snapshot.ex
@@ -21,9 +21,6 @@ defmodule Jido.Browser.Actions.Snapshot do
   use Jido.Browser.Action,
     name: "browser_snapshot",
     description: "Get comprehensive LLM-friendly snapshot of the current page state",
-    category: "Browser",
-    tags: ["browser", "snapshot", "observe", "page", "web", "ai"],
-    vsn: "2.0.0",
     schema:
       Zoi.object(%{
         include_links: Zoi.boolean(description: "Include extracted links") |> Zoi.default(true) |> Zoi.optional(),

--- a/lib/jido_browser/actions/snapshot_url.ex
+++ b/lib/jido_browser/actions/snapshot_url.ex
@@ -26,9 +26,6 @@ defmodule Jido.Browser.Actions.SnapshotUrl do
     description:
       "Navigate to a URL and return a comprehensive LLM-friendly snapshot " <>
         "including content, links, forms, and heading structure. Manages browser session automatically.",
-    category: "Browser",
-    tags: ["browser", "web", "snapshot", "observe", "ai"],
-    vsn: "2.0.0",
     schema:
       Zoi.object(%{
         url: Zoi.string(description: "The URL to snapshot"),

--- a/lib/jido_browser/actions/start_session.ex
+++ b/lib/jido_browser/actions/start_session.ex
@@ -16,9 +16,6 @@ defmodule Jido.Browser.Actions.StartSession do
   use Jido.Browser.Action,
     name: "browser_start_session",
     description: "Start a new browser session",
-    category: "Browser",
-    tags: ["browser", "session", "lifecycle"],
-    vsn: "2.0.0",
     schema:
       Zoi.object(%{
         headless: Zoi.boolean(description: "Run in headless mode") |> Zoi.optional(),

--- a/lib/jido_browser/actions/switch_tab.ex
+++ b/lib/jido_browser/actions/switch_tab.ex
@@ -6,9 +6,6 @@ defmodule Jido.Browser.Actions.SwitchTab do
   use Jido.Browser.Action,
     name: "browser_switch_tab",
     description: "Switch to another browser tab",
-    category: "Browser",
-    tags: ["browser", "tabs", "navigation"],
-    vsn: "2.0.0",
     schema:
       Zoi.object(%{
         index: Zoi.integer(description: "Tab index to activate"),

--- a/lib/jido_browser/actions/type.ex
+++ b/lib/jido_browser/actions/type.ex
@@ -15,9 +15,6 @@ defmodule Jido.Browser.Actions.Type do
   use Jido.Browser.Action,
     name: "browser_type",
     description: "Type text into an element in the browser",
-    category: "Browser",
-    tags: ["browser", "interaction", "input", "web"],
-    vsn: "2.0.0",
     schema:
       Zoi.object(%{
         selector: Zoi.string(description: "CSS selector for the input element"),

--- a/lib/jido_browser/actions/wait.ex
+++ b/lib/jido_browser/actions/wait.ex
@@ -16,9 +16,6 @@ defmodule Jido.Browser.Actions.Wait do
   use Jido.Browser.Action,
     name: "browser_wait",
     description: "Wait for a specified number of milliseconds",
-    category: "Browser",
-    tags: ["browser", "wait", "sync", "web"],
-    vsn: "2.0.0",
     schema: Zoi.object(%{ms: Zoi.integer(description: "Milliseconds to wait")})
 
   @impl true

--- a/lib/jido_browser/actions/wait_for_navigation.ex
+++ b/lib/jido_browser/actions/wait_for_navigation.ex
@@ -17,9 +17,6 @@ defmodule Jido.Browser.Actions.WaitForNavigation do
   use Jido.Browser.Action,
     name: "browser_wait_for_navigation",
     description: "Wait for page navigation to complete",
-    category: "Browser",
-    tags: ["browser", "wait", "navigation", "web"],
-    vsn: "2.0.0",
     schema:
       Zoi.object(%{
         url: Zoi.string(description: "URL pattern to match (substring match)") |> Zoi.optional(),

--- a/lib/jido_browser/actions/wait_for_selector.ex
+++ b/lib/jido_browser/actions/wait_for_selector.ex
@@ -17,9 +17,6 @@ defmodule Jido.Browser.Actions.WaitForSelector do
   use Jido.Browser.Action,
     name: "browser_wait_for_selector",
     description: "Wait for an element to appear, disappear, or change visibility state",
-    category: "Browser",
-    tags: ["browser", "wait", "sync", "web"],
-    vsn: "2.0.0",
     schema:
       Zoi.object(%{
         selector: Zoi.string(description: "CSS selector to wait for"),

--- a/lib/jido_browser/actions/web_fetch.ex
+++ b/lib/jido_browser/actions/web_fetch.ex
@@ -12,9 +12,6 @@ defmodule Jido.Browser.Actions.WebFetch do
     description:
       "Fetch a URL over HTTP(S) with domain policy controls, Extractous-backed document extraction, " <>
         "optional focused filtering, approximate token caps, and citation-ready passages.",
-    category: "Browser",
-    tags: ["browser", "web", "fetch", "http", "retrieval"],
-    vsn: "2.0.0",
     schema:
       Zoi.object(%{
         url: Zoi.string(description: "The URL to fetch"),

--- a/lib/jido_browser/plugin.ex
+++ b/lib/jido_browser/plugin.ex
@@ -32,68 +32,12 @@ defmodule Jido.Browser.Plugin do
   * `Evaluate` - Execute JavaScript in the browser
   """
 
+  alias Jido.Browser.ActionRegistry
   alias Jido.Browser.Deprecations
 
-  @action_registry [
-    # Session lifecycle
-    {Jido.Browser.Actions.StartSession, "browser.start_session"},
-    {Jido.Browser.Actions.EndSession, "browser.end_session"},
-    {Jido.Browser.Actions.GetStatus, "browser.get_status"},
-    {Jido.Browser.Actions.PoolStatus, "browser.pool_status"},
-    {Jido.Browser.Actions.SaveState, "browser.save_state"},
-    {Jido.Browser.Actions.LoadState, "browser.load_state"},
-    # Navigation
-    {Jido.Browser.Actions.Navigate, "browser.navigate"},
-    {Jido.Browser.Actions.Back, "browser.back"},
-    {Jido.Browser.Actions.Forward, "browser.forward"},
-    {Jido.Browser.Actions.Reload, "browser.reload"},
-    {Jido.Browser.Actions.GetUrl, "browser.get_url"},
-    {Jido.Browser.Actions.GetTitle, "browser.get_title"},
-    # Interaction
-    {Jido.Browser.Actions.Click, "browser.click"},
-    {Jido.Browser.Actions.Type, "browser.type"},
-    {Jido.Browser.Actions.Hover, "browser.hover"},
-    {Jido.Browser.Actions.Focus, "browser.focus"},
-    {Jido.Browser.Actions.Scroll, "browser.scroll"},
-    {Jido.Browser.Actions.SelectOption, "browser.select_option"},
-    # Waiting/synchronization
-    {Jido.Browser.Actions.Wait, "browser.wait"},
-    {Jido.Browser.Actions.WaitForSelector, "browser.wait_for_selector"},
-    {Jido.Browser.Actions.WaitForNavigation, "browser.wait_for_navigation"},
-    # Element queries
-    {Jido.Browser.Actions.Query, "browser.query"},
-    {Jido.Browser.Actions.GetText, "browser.get_text"},
-    {Jido.Browser.Actions.GetAttribute, "browser.get_attribute"},
-    {Jido.Browser.Actions.IsVisible, "browser.is_visible"},
-    # Tabs
-    {Jido.Browser.Actions.ListTabs, "browser.tab_list"},
-    {Jido.Browser.Actions.NewTab, "browser.tab_new"},
-    {Jido.Browser.Actions.SwitchTab, "browser.tab_switch"},
-    {Jido.Browser.Actions.CloseTab, "browser.tab_close"},
-    # Content extraction
-    {Jido.Browser.Actions.Snapshot, "browser.snapshot"},
-    {Jido.Browser.Actions.Screenshot, "browser.screenshot"},
-    {Jido.Browser.Actions.ExtractContent, "browser.extract"},
-    # Diagnostics
-    {Jido.Browser.Actions.Console, "browser.console"},
-    {Jido.Browser.Actions.Errors, "browser.errors"},
-    # Advanced
-    {Jido.Browser.Actions.Evaluate, "browser.evaluate"},
-    # Self-contained composite actions (manage own session)
-    {Jido.Browser.Actions.ReadPage, "browser.read_page"},
-    {Jido.Browser.Actions.SnapshotUrl, "browser.snapshot_url"},
-    {Jido.Browser.Actions.SearchWeb, "browser.search_web"},
-    {Jido.Browser.Actions.WebFetch, "browser.web_fetch"},
-    {Jido.Browser.Actions.FetchRich, "browser.fetch_rich"}
-  ]
-
-  for {action, _signal_name} <- @action_registry do
-    Code.ensure_compiled!(action)
-  end
-
-  @action_modules Enum.map(@action_registry, &elem(&1, 0))
-  @signal_routes Enum.map(@action_registry, fn {action, signal_name} -> {signal_name, action} end)
-  @signal_patterns Enum.map(@action_registry, &elem(&1, 1))
+  @action_modules ActionRegistry.actions()
+  @signal_routes ActionRegistry.signal_routes()
+  @signal_patterns ActionRegistry.signal_patterns()
 
   use Jido.Plugin,
     name: "browser",

--- a/test/jido_browser/action_registry_test.exs
+++ b/test/jido_browser/action_registry_test.exs
@@ -1,0 +1,94 @@
+defmodule Jido.Browser.ActionRegistryTest do
+  use ExUnit.Case, async: true
+
+  alias Jido.Browser.ActionRegistry
+  alias Jido.Browser.ActionRegistry.Entry
+  alias Jido.Browser.Actions
+
+  @category_contract [
+    session: [
+      Actions.StartSession,
+      Actions.EndSession,
+      Actions.GetStatus,
+      Actions.PoolStatus,
+      Actions.SaveState,
+      Actions.LoadState
+    ],
+    navigation: [
+      Actions.Navigate,
+      Actions.Back,
+      Actions.Forward,
+      Actions.Reload,
+      Actions.GetUrl,
+      Actions.GetTitle
+    ],
+    interaction: [
+      Actions.Click,
+      Actions.Type,
+      Actions.Hover,
+      Actions.Focus,
+      Actions.Scroll,
+      Actions.SelectOption
+    ],
+    synchronization: [Actions.Wait, Actions.WaitForSelector, Actions.WaitForNavigation],
+    query: [Actions.Query, Actions.GetText, Actions.GetAttribute, Actions.IsVisible],
+    tabs: [Actions.ListTabs, Actions.NewTab, Actions.SwitchTab, Actions.CloseTab],
+    content: [Actions.Snapshot, Actions.Screenshot, Actions.ExtractContent],
+    diagnostics: [Actions.Console, Actions.Errors],
+    advanced: [Actions.Evaluate],
+    composite: [Actions.ReadPage, Actions.SnapshotUrl, Actions.SearchWeb, Actions.WebFetch, Actions.FetchRich]
+  ]
+
+  test "owns complete metadata in stable tool order" do
+    entries = ActionRegistry.entries()
+    expected_actions = Enum.flat_map(@category_contract, &elem(&1, 1))
+
+    assert length(entries) == 40
+    assert Enum.map(entries, & &1.action) == expected_actions
+    assert ActionRegistry.actions() == expected_actions
+    assert ActionRegistry.tool_contract_version() == 3
+
+    for entry <- entries do
+      assert %Entry{} = entry
+      assert entry.support_level == :supported
+      assert entry.tool_contract_version == 3
+      assert "browser" in entry.tags
+      assert String.starts_with?(entry.signal_name, "browser.")
+    end
+
+    assert length(Enum.uniq_by(entries, & &1.action)) == 40
+    assert length(Enum.uniq_by(entries, & &1.signal_name)) == 40
+  end
+
+  test "groups and filters registry entries" do
+    for {category, expected_actions} <- @category_contract do
+      assert ActionRegistry.by_category(category) |> Enum.map(& &1.action) == expected_actions
+    end
+
+    assert ActionRegistry.with_tag("diagnostics") |> Enum.map(& &1.action) == [
+             Actions.PoolStatus,
+             Actions.Console,
+             Actions.Errors
+           ]
+
+    assert ActionRegistry.by_support_level(:supported) == ActionRegistry.entries()
+    assert ActionRegistry.by_support_level(:unsupported) == []
+  end
+
+  test "looks up metadata by action or signal name" do
+    assert {:ok, %Entry{} = by_action} = ActionRegistry.fetch(Actions.Navigate)
+    assert {:ok, %Entry{} = by_signal} = ActionRegistry.fetch("browser.navigate")
+    assert by_action == by_signal
+    assert by_action.category == :navigation
+    assert "navigation" in by_action.tags
+    assert ActionRegistry.fetch("browser.unknown") == :error
+  end
+
+  test "keeps Action definitions free of browser catalog metadata" do
+    for action <- ActionRegistry.actions() do
+      assert action.category() == nil
+      assert action.tags() == []
+      assert action.vsn() == nil
+    end
+  end
+end


### PR DESCRIPTION
Closes #78

## Summary

- add `Jido.Browser.ActionRegistry` as the single owner of action order, signal routes, functional categories, tags, support level, and browser-tool contract version
- make `Jido.Browser.Plugin` use the shared registry
- remove `category`, `tags`, and stale `vsn` declarations from all 40 production actions
- add direct ordering, lookup, grouping, filtering, uniqueness, and Action-cleanup contract tests

## Breaking change

Browser catalog metadata is no longer available through `Action.category/0`, `Action.tags/0`, or `Action.vsn/0`. Catalog consumers must use `Jido.Browser.ActionRegistry`. The browser-tool contract major version is now `3`.

## Verification

- `mix compile --warnings-as-errors`
- `mix credo --strict`
- `mix test` — 416 passed, 26 excluded
