### PR TITLE
feat!: add static Zoi output schemas to browser actions

### DIFF
--- a/lib/jido_browser/actions/back.ex
+++ b/lib/jido_browser/actions/back.ex
@@ -15,7 +15,14 @@ defmodule Jido.Browser.Actions.Back do
   use Jido.Browser.Action,
     name: "browser_back",
     description: "Navigate back in browser history",
-    schema: Zoi.object(%{timeout: Zoi.integer(description: "Timeout in milliseconds") |> Zoi.optional()})
+    schema: Zoi.object(%{timeout: Zoi.integer(description: "Timeout in milliseconds") |> Zoi.optional()}),
+    output_schema:
+      Zoi.object(%{
+        status: Zoi.literal("success"),
+        action: Zoi.literal("back"),
+        result: Zoi.map(),
+        session: Zoi.any()
+      })
 
   alias Jido.Browser.ActionHelpers
   alias Jido.Browser.Error

--- a/lib/jido_browser/actions/click.ex
+++ b/lib/jido_browser/actions/click.ex
@@ -23,6 +23,13 @@ defmodule Jido.Browser.Actions.Click do
           Zoi.string(description: "Optional text content to match within the selector")
           |> Zoi.optional(),
         timeout: Zoi.integer(description: "Timeout in milliseconds") |> Zoi.optional()
+      }),
+    output_schema:
+      Zoi.object(%{
+        status: Zoi.literal("success"),
+        selector: Zoi.string(),
+        result: Zoi.map(),
+        session: Zoi.any()
       })
 
   alias Jido.Browser.ActionHelpers

--- a/lib/jido_browser/actions/close_tab.ex
+++ b/lib/jido_browser/actions/close_tab.ex
@@ -10,6 +10,13 @@ defmodule Jido.Browser.Actions.CloseTab do
       Zoi.object(%{
         index: Zoi.integer(description: "Optional tab index to close") |> Zoi.optional(),
         timeout: Zoi.integer(description: "Timeout in milliseconds") |> Zoi.optional()
+      }),
+    output_schema:
+      Zoi.object(%{
+        status: Zoi.literal("success"),
+        index: Zoi.integer() |> Zoi.nullable(),
+        result: Zoi.map(),
+        session: Zoi.any()
       })
 
   alias Jido.Browser.ActionHelpers

--- a/lib/jido_browser/actions/console.ex
+++ b/lib/jido_browser/actions/console.ex
@@ -6,7 +6,14 @@ defmodule Jido.Browser.Actions.Console do
   use Jido.Browser.Action,
     name: "browser_console",
     description: "Read browser console messages",
-    schema: Zoi.object(%{timeout: Zoi.integer(description: "Timeout in milliseconds") |> Zoi.optional()})
+    schema: Zoi.object(%{timeout: Zoi.integer(description: "Timeout in milliseconds") |> Zoi.optional()}),
+    output_schema:
+      Zoi.object(%{
+        status: Zoi.literal("success"),
+        messages: Zoi.list(Zoi.map()),
+        result: Zoi.map(),
+        session: Zoi.any()
+      })
 
   alias Jido.Browser.ActionHelpers
   alias Jido.Browser.Error

--- a/lib/jido_browser/actions/end_session.ex
+++ b/lib/jido_browser/actions/end_session.ex
@@ -16,7 +16,12 @@ defmodule Jido.Browser.Actions.EndSession do
   use Jido.Browser.Action,
     name: "browser_end_session",
     description: "End the current browser session",
-    schema: Zoi.object(%{})
+    schema: Zoi.object(%{}),
+    output_schema:
+      Zoi.object(%{
+        status: Zoi.literal("success"),
+        message: Zoi.string()
+      })
 
   alias Jido.Browser.ActionHelpers
   alias Jido.Browser.Error

--- a/lib/jido_browser/actions/errors.ex
+++ b/lib/jido_browser/actions/errors.ex
@@ -6,7 +6,14 @@ defmodule Jido.Browser.Actions.Errors do
   use Jido.Browser.Action,
     name: "browser_errors",
     description: "Read browser runtime errors",
-    schema: Zoi.object(%{timeout: Zoi.integer(description: "Timeout in milliseconds") |> Zoi.optional()})
+    schema: Zoi.object(%{timeout: Zoi.integer(description: "Timeout in milliseconds") |> Zoi.optional()}),
+    output_schema:
+      Zoi.object(%{
+        status: Zoi.literal("success"),
+        errors: Zoi.list(Zoi.map()),
+        result: Zoi.map(),
+        session: Zoi.any()
+      })
 
   alias Jido.Browser.ActionHelpers
   alias Jido.Browser.Error

--- a/lib/jido_browser/actions/evaluate.ex
+++ b/lib/jido_browser/actions/evaluate.ex
@@ -20,6 +20,12 @@ defmodule Jido.Browser.Actions.Evaluate do
       Zoi.object(%{
         script: Zoi.string(description: "JavaScript code to execute"),
         timeout: Zoi.integer(description: "Timeout in milliseconds") |> Zoi.optional()
+      }),
+    output_schema:
+      Zoi.object(%{
+        status: Zoi.literal("success"),
+        result: Zoi.any(),
+        session: Zoi.any()
       })
 
   alias Jido.Browser.ActionHelpers

--- a/lib/jido_browser/actions/extract_content.ex
+++ b/lib/jido_browser/actions/extract_content.ex
@@ -31,6 +31,14 @@ defmodule Jido.Browser.Actions.ExtractContent do
           Zoi.enum([:markdown, :html, :text], description: "Output format")
           |> Zoi.default(:markdown)
           |> Zoi.optional()
+      }),
+    output_schema:
+      Zoi.object(%{
+        status: Zoi.literal("success"),
+        content: Zoi.string(),
+        format: Zoi.enum([:markdown, :html, :text]),
+        length: Zoi.integer(gte: 0),
+        session: Zoi.any()
       })
 
   alias Jido.Browser.ActionHelpers

--- a/lib/jido_browser/actions/fetch_rich.ex
+++ b/lib/jido_browser/actions/fetch_rich.ex
@@ -74,6 +74,30 @@ defmodule Jido.Browser.Actions.FetchRich do
         max_uses:
           Zoi.integer(description: "Maximum successful rich fetch calls allowed in current skill state")
           |> Zoi.optional()
+      }),
+    output_schema:
+      Zoi.object(%{
+        status: Zoi.literal("success"),
+        url: Zoi.string(),
+        final_url: Zoi.string(),
+        title: Zoi.string() |> Zoi.nullish(),
+        content: Zoi.string(),
+        format: Zoi.enum([:markdown, :text, :html]),
+        content_type: Zoi.string(),
+        document_type: Zoi.atom(),
+        retrieved_at: Zoi.string(),
+        estimated_tokens: Zoi.integer(gte: 0),
+        original_estimated_tokens: Zoi.integer(gte: 0),
+        truncated: Zoi.boolean(),
+        filtered: Zoi.boolean(),
+        focus_matches: Zoi.integer(gte: 0),
+        cached: Zoi.boolean(),
+        citations: Zoi.map(),
+        passages: Zoi.list(Zoi.map()),
+        metadata: Zoi.map() |> Zoi.optional(),
+        retrieval_path: Zoi.enum([:web_fetch, :browser]),
+        fallback_reason: Zoi.any(),
+        blocked?: Zoi.boolean()
       })
 
   alias Jido.Browser.Error

--- a/lib/jido_browser/actions/focus.ex
+++ b/lib/jido_browser/actions/focus.ex
@@ -20,6 +20,13 @@ defmodule Jido.Browser.Actions.Focus do
       Zoi.object(%{
         selector: Zoi.string(description: "CSS selector for the element to focus"),
         timeout: Zoi.integer(description: "Timeout in milliseconds") |> Zoi.optional()
+      }),
+    output_schema:
+      Zoi.object(%{
+        status: Zoi.literal("success"),
+        selector: Zoi.string(),
+        result: Zoi.map(),
+        session: Zoi.any()
       })
 
   alias Jido.Browser.ActionHelpers

--- a/lib/jido_browser/actions/forward.ex
+++ b/lib/jido_browser/actions/forward.ex
@@ -15,7 +15,14 @@ defmodule Jido.Browser.Actions.Forward do
   use Jido.Browser.Action,
     name: "browser_forward",
     description: "Navigate forward in browser history",
-    schema: Zoi.object(%{timeout: Zoi.integer(description: "Timeout in milliseconds") |> Zoi.optional()})
+    schema: Zoi.object(%{timeout: Zoi.integer(description: "Timeout in milliseconds") |> Zoi.optional()}),
+    output_schema:
+      Zoi.object(%{
+        status: Zoi.literal("success"),
+        action: Zoi.literal("forward"),
+        result: Zoi.map(),
+        session: Zoi.any()
+      })
 
   alias Jido.Browser.ActionHelpers
   alias Jido.Browser.Error

--- a/lib/jido_browser/actions/get_attribute.ex
+++ b/lib/jido_browser/actions/get_attribute.ex
@@ -20,6 +20,14 @@ defmodule Jido.Browser.Actions.GetAttribute do
       Zoi.object(%{
         selector: Zoi.string(description: "CSS selector for the element"),
         attribute: Zoi.string(description: "Attribute name to get")
+      }),
+    output_schema:
+      Zoi.object(%{
+        status: Zoi.literal("success"),
+        selector: Zoi.string(),
+        attribute: Zoi.string(),
+        value: Zoi.string(),
+        session: Zoi.any()
       })
 
   alias Jido.Browser.ActionHelpers

--- a/lib/jido_browser/actions/get_status.ex
+++ b/lib/jido_browser/actions/get_status.ex
@@ -17,7 +17,16 @@ defmodule Jido.Browser.Actions.GetStatus do
   use Jido.Browser.Action,
     name: "browser_get_status",
     description: "Get current session status (url, title, is_alive)",
-    schema: Zoi.object(%{})
+    schema: Zoi.object(%{}),
+    output_schema:
+      Zoi.object(%{
+        status: Zoi.literal("success"),
+        alive: Zoi.boolean(),
+        url: Zoi.string() |> Zoi.nullable(),
+        title: Zoi.string() |> Zoi.nullable(),
+        adapter: Zoi.string(),
+        session: Zoi.any()
+      })
 
   alias Jido.Browser.ActionHelpers
 

--- a/lib/jido_browser/actions/get_text.ex
+++ b/lib/jido_browser/actions/get_text.ex
@@ -23,6 +23,14 @@ defmodule Jido.Browser.Actions.GetText do
           Zoi.boolean(description: "Get text from all matching elements")
           |> Zoi.default(false)
           |> Zoi.optional()
+      }),
+    output_schema:
+      Zoi.object(%{
+        status: Zoi.literal("success"),
+        selector: Zoi.string(),
+        text: Zoi.string() |> Zoi.optional(),
+        texts: Zoi.list(Zoi.string()) |> Zoi.optional(),
+        session: Zoi.any()
       })
 
   alias Jido.Browser.ActionHelpers

--- a/lib/jido_browser/actions/get_title.ex
+++ b/lib/jido_browser/actions/get_title.ex
@@ -15,7 +15,13 @@ defmodule Jido.Browser.Actions.GetTitle do
   use Jido.Browser.Action,
     name: "browser_get_title",
     description: "Get the current page title",
-    schema: Zoi.object(%{timeout: Zoi.integer(description: "Timeout in milliseconds") |> Zoi.optional()})
+    schema: Zoi.object(%{timeout: Zoi.integer(description: "Timeout in milliseconds") |> Zoi.optional()}),
+    output_schema:
+      Zoi.object(%{
+        status: Zoi.literal("success"),
+        title: Zoi.string(),
+        session: Zoi.any()
+      })
 
   alias Jido.Browser.ActionHelpers
   alias Jido.Browser.Error

--- a/lib/jido_browser/actions/get_url.ex
+++ b/lib/jido_browser/actions/get_url.ex
@@ -15,7 +15,13 @@ defmodule Jido.Browser.Actions.GetUrl do
   use Jido.Browser.Action,
     name: "browser_get_url",
     description: "Get the current page URL",
-    schema: Zoi.object(%{timeout: Zoi.integer(description: "Timeout in milliseconds") |> Zoi.optional()})
+    schema: Zoi.object(%{timeout: Zoi.integer(description: "Timeout in milliseconds") |> Zoi.optional()}),
+    output_schema:
+      Zoi.object(%{
+        status: Zoi.literal("success"),
+        url: Zoi.string(),
+        session: Zoi.any()
+      })
 
   alias Jido.Browser.ActionHelpers
   alias Jido.Browser.Error

--- a/lib/jido_browser/actions/hover.ex
+++ b/lib/jido_browser/actions/hover.ex
@@ -20,6 +20,13 @@ defmodule Jido.Browser.Actions.Hover do
       Zoi.object(%{
         selector: Zoi.string(description: "CSS selector for the element to hover"),
         timeout: Zoi.integer(description: "Timeout in milliseconds") |> Zoi.optional()
+      }),
+    output_schema:
+      Zoi.object(%{
+        status: Zoi.literal("success"),
+        selector: Zoi.string(),
+        result: Zoi.map(),
+        session: Zoi.any()
       })
 
   alias Jido.Browser.ActionHelpers

--- a/lib/jido_browser/actions/is_visible.ex
+++ b/lib/jido_browser/actions/is_visible.ex
@@ -16,7 +16,13 @@ defmodule Jido.Browser.Actions.IsVisible do
   use Jido.Browser.Action,
     name: "browser_is_visible",
     description: "Check if an element is visible",
-    schema: Zoi.object(%{selector: Zoi.string(description: "CSS selector for the element")})
+    schema: Zoi.object(%{selector: Zoi.string(description: "CSS selector for the element")}),
+    output_schema:
+      Zoi.object(%{
+        exists: Zoi.boolean(),
+        visible: Zoi.boolean(),
+        session: Zoi.any()
+      })
 
   alias Jido.Browser.ActionHelpers
   alias Jido.Browser.Error

--- a/lib/jido_browser/actions/list_tabs.ex
+++ b/lib/jido_browser/actions/list_tabs.ex
@@ -6,7 +6,14 @@ defmodule Jido.Browser.Actions.ListTabs do
   use Jido.Browser.Action,
     name: "browser_list_tabs",
     description: "List open browser tabs",
-    schema: Zoi.object(%{timeout: Zoi.integer(description: "Timeout in milliseconds") |> Zoi.optional()})
+    schema: Zoi.object(%{timeout: Zoi.integer(description: "Timeout in milliseconds") |> Zoi.optional()}),
+    output_schema:
+      Zoi.object(%{
+        status: Zoi.literal("success"),
+        tabs: Zoi.list(Zoi.map()),
+        result: Zoi.map(),
+        session: Zoi.any()
+      })
 
   alias Jido.Browser.ActionHelpers
   alias Jido.Browser.Error

--- a/lib/jido_browser/actions/load_state.ex
+++ b/lib/jido_browser/actions/load_state.ex
@@ -10,6 +10,13 @@ defmodule Jido.Browser.Actions.LoadState do
       Zoi.object(%{
         path: Zoi.string(description: "Filesystem path of the saved session state"),
         timeout: Zoi.integer(description: "Timeout in milliseconds") |> Zoi.optional()
+      }),
+    output_schema:
+      Zoi.object(%{
+        status: Zoi.literal("success"),
+        path: Zoi.string(),
+        result: Zoi.map(),
+        session: Zoi.any()
       })
 
   alias Jido.Browser.ActionHelpers

--- a/lib/jido_browser/actions/navigate.ex
+++ b/lib/jido_browser/actions/navigate.ex
@@ -19,6 +19,13 @@ defmodule Jido.Browser.Actions.Navigate do
       Zoi.object(%{
         url: Zoi.string(description: "The URL to navigate to"),
         timeout: Zoi.integer(description: "Timeout in milliseconds") |> Zoi.optional()
+      }),
+    output_schema:
+      Zoi.object(%{
+        status: Zoi.literal("success"),
+        url: Zoi.string(),
+        result: Zoi.map(),
+        session: Zoi.any()
       })
 
   alias Jido.Browser.ActionHelpers

--- a/lib/jido_browser/actions/new_tab.ex
+++ b/lib/jido_browser/actions/new_tab.ex
@@ -10,6 +10,13 @@ defmodule Jido.Browser.Actions.NewTab do
       Zoi.object(%{
         url: Zoi.string(description: "Optional URL to open in the new tab") |> Zoi.optional(),
         timeout: Zoi.integer(description: "Timeout in milliseconds") |> Zoi.optional()
+      }),
+    output_schema:
+      Zoi.object(%{
+        status: Zoi.literal("success"),
+        url: Zoi.string() |> Zoi.nullable(),
+        result: Zoi.map(),
+        session: Zoi.any()
       })
 
   alias Jido.Browser.ActionHelpers

--- a/lib/jido_browser/actions/pool_status.ex
+++ b/lib/jido_browser/actions/pool_status.ex
@@ -11,6 +11,12 @@ defmodule Jido.Browser.Actions.PoolStatus do
         pool:
           Zoi.any(description: "Warm pool name or pid. Defaults to plugin pool state.")
           |> Zoi.optional()
+      }),
+    output_schema:
+      Zoi.object(%{
+        status: Zoi.literal("success"),
+        pool: Zoi.any(),
+        pool_status: Zoi.map()
       })
 
   alias Jido.Browser.Error

--- a/lib/jido_browser/actions/query.ex
+++ b/lib/jido_browser/actions/query.ex
@@ -23,6 +23,13 @@ defmodule Jido.Browser.Actions.Query do
           Zoi.integer(description: "Maximum number of elements to return")
           |> Zoi.default(10)
           |> Zoi.optional()
+      }),
+    output_schema:
+      Zoi.object(%{
+        status: Zoi.literal("success"),
+        count: Zoi.integer(gte: 0),
+        elements: Zoi.list(Zoi.map()),
+        session: Zoi.any()
       })
 
   alias Jido.Browser.ActionHelpers

--- a/lib/jido_browser/actions/read_page.ex
+++ b/lib/jido_browser/actions/read_page.ex
@@ -36,6 +36,12 @@ defmodule Jido.Browser.Actions.ReadPage do
         adapter: Zoi.atom(description: "Browser adapter module") |> Zoi.optional(),
         headless: Zoi.boolean(description: "Run in headless mode") |> Zoi.optional(),
         timeout: Zoi.integer(description: "Default browser timeout in ms") |> Zoi.optional()
+      }),
+    output_schema:
+      Zoi.object(%{
+        url: Zoi.string(),
+        content: Zoi.string(),
+        format: Zoi.enum([:markdown, :text, :html])
       })
 
   @impl true

--- a/lib/jido_browser/actions/reload.ex
+++ b/lib/jido_browser/actions/reload.ex
@@ -15,7 +15,14 @@ defmodule Jido.Browser.Actions.Reload do
   use Jido.Browser.Action,
     name: "browser_reload",
     description: "Reload the current page",
-    schema: Zoi.object(%{timeout: Zoi.integer(description: "Timeout in milliseconds") |> Zoi.optional()})
+    schema: Zoi.object(%{timeout: Zoi.integer(description: "Timeout in milliseconds") |> Zoi.optional()}),
+    output_schema:
+      Zoi.object(%{
+        status: Zoi.literal("success"),
+        action: Zoi.literal("reload"),
+        result: Zoi.map(),
+        session: Zoi.any()
+      })
 
   alias Jido.Browser.ActionHelpers
   alias Jido.Browser.Error

--- a/lib/jido_browser/actions/save_state.ex
+++ b/lib/jido_browser/actions/save_state.ex
@@ -10,6 +10,13 @@ defmodule Jido.Browser.Actions.SaveState do
       Zoi.object(%{
         path: Zoi.string(description: "Filesystem path where session state will be stored"),
         timeout: Zoi.integer(description: "Timeout in milliseconds") |> Zoi.optional()
+      }),
+    output_schema:
+      Zoi.object(%{
+        status: Zoi.literal("success"),
+        path: Zoi.string(),
+        result: Zoi.map(),
+        session: Zoi.any()
       })
 
   alias Jido.Browser.ActionHelpers

--- a/lib/jido_browser/actions/screenshot.ex
+++ b/lib/jido_browser/actions/screenshot.ex
@@ -27,6 +27,16 @@ defmodule Jido.Browser.Actions.Screenshot do
           |> Zoi.default(:png)
           |> Zoi.optional(),
         save_path: Zoi.string(description: "Optional file path to save the screenshot") |> Zoi.optional()
+      }),
+    output_schema:
+      Zoi.object(%{
+        status: Zoi.literal("success"),
+        mime: Zoi.string(),
+        size: Zoi.integer(gte: 0),
+        base64: Zoi.string(),
+        session: Zoi.any(),
+        saved_to: Zoi.string() |> Zoi.optional(),
+        save_error: Zoi.string() |> Zoi.optional()
       })
 
   alias Jido.Browser.ActionHelpers

--- a/lib/jido_browser/actions/scroll.ex
+++ b/lib/jido_browser/actions/scroll.ex
@@ -26,6 +26,12 @@ defmodule Jido.Browser.Actions.Scroll do
           Zoi.enum([:up, :down, :top, :bottom], description: "Preset scroll direction")
           |> Zoi.optional(),
         selector: Zoi.string(description: "CSS selector to scroll element into view") |> Zoi.optional()
+      }),
+    output_schema:
+      Zoi.object(%{
+        status: Zoi.literal("success"),
+        result: Zoi.map(),
+        session: Zoi.any()
       })
 
   alias Jido.Browser.ActionHelpers

--- a/lib/jido_browser/actions/search_web.ex
+++ b/lib/jido_browser/actions/search_web.ex
@@ -38,6 +38,12 @@ defmodule Jido.Browser.Actions.SearchWeb do
         freshness:
           Zoi.string(description: "Freshness filter: pd (24h), pw (week), pm (month), py (year)")
           |> Zoi.optional()
+      }),
+    output_schema:
+      Zoi.object(%{
+        query: Zoi.string(),
+        results: Zoi.list(Zoi.map()),
+        count: Zoi.integer(gte: 0)
       })
 
   @brave_api_url "https://api.search.brave.com/res/v1/web/search"

--- a/lib/jido_browser/actions/select_option.ex
+++ b/lib/jido_browser/actions/select_option.ex
@@ -23,6 +23,13 @@ defmodule Jido.Browser.Actions.SelectOption do
         value: Zoi.string(description: "Option value to select") |> Zoi.optional(),
         label: Zoi.string(description: "Option label/text to select") |> Zoi.optional(),
         index: Zoi.integer(description: "Option index to select (0-based)") |> Zoi.optional()
+      }),
+    output_schema:
+      Zoi.object(%{
+        status: Zoi.literal("success"),
+        selector: Zoi.string(),
+        result: Zoi.map(),
+        session: Zoi.any()
       })
 
   alias Jido.Browser.ActionHelpers

--- a/lib/jido_browser/actions/snapshot.ex
+++ b/lib/jido_browser/actions/snapshot.ex
@@ -34,6 +34,21 @@ defmodule Jido.Browser.Actions.Snapshot do
           Zoi.string(description: "CSS selector to scope extraction")
           |> Zoi.default("body")
           |> Zoi.optional()
+      }),
+    output_schema:
+      Zoi.object(%{
+        status: Zoi.literal("success"),
+        session: Zoi.any(),
+        url: Zoi.string() |> Zoi.nullish(),
+        title: Zoi.string() |> Zoi.nullish(),
+        origin: Zoi.string() |> Zoi.nullish(),
+        snapshot: Zoi.string() |> Zoi.optional(),
+        content: Zoi.string() |> Zoi.optional(),
+        refs: Zoi.map() |> Zoi.optional(),
+        links: Zoi.list(Zoi.map()) |> Zoi.optional(),
+        forms: Zoi.list(Zoi.map()) |> Zoi.optional(),
+        headings: Zoi.list(Zoi.map()) |> Zoi.optional(),
+        raw: Zoi.map() |> Zoi.optional()
       })
 
   alias Jido.Browser.ActionHelpers

--- a/lib/jido_browser/actions/snapshot_url.ex
+++ b/lib/jido_browser/actions/snapshot_url.ex
@@ -45,6 +45,21 @@ defmodule Jido.Browser.Actions.SnapshotUrl do
         adapter: Zoi.atom(description: "Browser adapter module") |> Zoi.optional(),
         headless: Zoi.boolean(description: "Run in headless mode") |> Zoi.optional(),
         timeout: Zoi.integer(description: "Default browser timeout in ms") |> Zoi.optional()
+      }),
+    output_schema:
+      Zoi.object(%{
+        status: Zoi.literal("success"),
+        url: Zoi.string() |> Zoi.nullish(),
+        title: Zoi.string() |> Zoi.nullish(),
+        origin: Zoi.string() |> Zoi.nullish(),
+        snapshot: Zoi.string() |> Zoi.optional(),
+        content: Zoi.string() |> Zoi.optional(),
+        refs: Zoi.map() |> Zoi.optional(),
+        links: Zoi.list(Zoi.map()) |> Zoi.optional(),
+        forms: Zoi.list(Zoi.map()) |> Zoi.optional(),
+        headings: Zoi.list(Zoi.map()) |> Zoi.optional(),
+        fallback: Zoi.boolean() |> Zoi.optional(),
+        raw: Zoi.map() |> Zoi.optional()
       })
 
   alias Jido.Browser.ActionHelpers

--- a/lib/jido_browser/actions/start_session.ex
+++ b/lib/jido_browser/actions/start_session.ex
@@ -23,6 +23,13 @@ defmodule Jido.Browser.Actions.StartSession do
         adapter: Zoi.atom(description: "Browser adapter module") |> Zoi.optional(),
         pool: Zoi.any(description: "Optional warm session pool name") |> Zoi.optional(),
         checkout_timeout: Zoi.integer(description: "Warm pool checkout timeout in ms") |> Zoi.optional()
+      }),
+    output_schema:
+      Zoi.object(%{
+        status: Zoi.literal("success"),
+        session: Zoi.any(),
+        adapter: Zoi.string(),
+        message: Zoi.string()
       })
 
   alias Jido.Browser.Error

--- a/lib/jido_browser/actions/switch_tab.ex
+++ b/lib/jido_browser/actions/switch_tab.ex
@@ -10,6 +10,13 @@ defmodule Jido.Browser.Actions.SwitchTab do
       Zoi.object(%{
         index: Zoi.integer(description: "Tab index to activate"),
         timeout: Zoi.integer(description: "Timeout in milliseconds") |> Zoi.optional()
+      }),
+    output_schema:
+      Zoi.object(%{
+        status: Zoi.literal("success"),
+        index: Zoi.integer(),
+        result: Zoi.map(),
+        session: Zoi.any()
       })
 
   alias Jido.Browser.ActionHelpers

--- a/lib/jido_browser/actions/type.ex
+++ b/lib/jido_browser/actions/type.ex
@@ -24,6 +24,13 @@ defmodule Jido.Browser.Actions.Type do
           |> Zoi.default(false)
           |> Zoi.optional(),
         timeout: Zoi.integer(description: "Timeout in milliseconds") |> Zoi.optional()
+      }),
+    output_schema:
+      Zoi.object(%{
+        status: Zoi.literal("success"),
+        selector: Zoi.string(),
+        result: Zoi.map(),
+        session: Zoi.any()
       })
 
   alias Jido.Browser.ActionHelpers

--- a/lib/jido_browser/actions/wait.ex
+++ b/lib/jido_browser/actions/wait.ex
@@ -16,7 +16,12 @@ defmodule Jido.Browser.Actions.Wait do
   use Jido.Browser.Action,
     name: "browser_wait",
     description: "Wait for a specified number of milliseconds",
-    schema: Zoi.object(%{ms: Zoi.integer(description: "Milliseconds to wait")})
+    schema: Zoi.object(%{ms: Zoi.integer(description: "Milliseconds to wait")}),
+    output_schema:
+      Zoi.object(%{
+        status: Zoi.literal("success"),
+        waited_ms: Zoi.integer()
+      })
 
   @impl true
   def run(%{ms: ms}, _context) do

--- a/lib/jido_browser/actions/wait_for_navigation.ex
+++ b/lib/jido_browser/actions/wait_for_navigation.ex
@@ -24,6 +24,13 @@ defmodule Jido.Browser.Actions.WaitForNavigation do
           Zoi.integer(description: "Maximum wait time in milliseconds")
           |> Zoi.default(30_000)
           |> Zoi.optional()
+      }),
+    output_schema:
+      Zoi.object(%{
+        status: Zoi.literal("success"),
+        url: Zoi.string() |> Zoi.nullable(),
+        elapsed_ms: Zoi.integer(gte: 0),
+        session: Zoi.any()
       })
 
   alias Jido.Browser.ActionHelpers

--- a/lib/jido_browser/actions/wait_for_selector.ex
+++ b/lib/jido_browser/actions/wait_for_selector.ex
@@ -30,6 +30,14 @@ defmodule Jido.Browser.Actions.WaitForSelector do
           Zoi.integer(description: "Maximum wait time in milliseconds")
           |> Zoi.default(30_000)
           |> Zoi.optional()
+      }),
+    output_schema:
+      Zoi.object(%{
+        status: Zoi.literal("success"),
+        selector: Zoi.string(),
+        state: Zoi.enum([:attached, :visible, :hidden, :detached]),
+        elapsed_ms: Zoi.integer(gte: 0),
+        session: Zoi.any()
       })
 
   alias Jido.Browser.ActionHelpers

--- a/lib/jido_browser/actions/web_fetch.ex
+++ b/lib/jido_browser/actions/web_fetch.ex
@@ -68,6 +68,27 @@ defmodule Jido.Browser.Actions.WebFetch do
         max_uses:
           Zoi.integer(description: "Maximum successful web fetch calls allowed in current skill state")
           |> Zoi.optional()
+      }),
+    output_schema:
+      Zoi.object(%{
+        status: Zoi.literal("success"),
+        url: Zoi.string(),
+        final_url: Zoi.string(),
+        title: Zoi.string() |> Zoi.nullish(),
+        content: Zoi.string(),
+        format: Zoi.enum([:markdown, :text, :html]),
+        content_type: Zoi.string(),
+        document_type: Zoi.atom(),
+        retrieved_at: Zoi.string(),
+        estimated_tokens: Zoi.integer(gte: 0),
+        original_estimated_tokens: Zoi.integer(gte: 0),
+        truncated: Zoi.boolean(),
+        filtered: Zoi.boolean(),
+        focus_matches: Zoi.integer(gte: 0),
+        cached: Zoi.boolean(),
+        citations: Zoi.map(),
+        passages: Zoi.list(Zoi.map()),
+        metadata: Zoi.map() |> Zoi.optional()
       })
 
   alias Jido.Browser.Error

--- a/test/jido_browser/action_contract_content_composite_test.exs
+++ b/test/jido_browser/action_contract_content_composite_test.exs
@@ -8,6 +8,27 @@ defmodule Jido.Browser.ActionContractContentCompositeTest do
   alias Jido.Browser.ActionContractToolExecutionProbe
   alias Jido.Browser.Actions
 
+  @web_fetch_output %{
+    status: {:literal, "success"},
+    url: :string,
+    final_url: :string,
+    title: {:optional, {:nullable, :string}},
+    content: :string,
+    format: {:in, [:markdown, :text, :html]},
+    content_type: :string,
+    document_type: :atom,
+    retrieved_at: :string,
+    estimated_tokens: :non_neg_integer,
+    original_estimated_tokens: :non_neg_integer,
+    truncated: :boolean,
+    filtered: :boolean,
+    focus_matches: :non_neg_integer,
+    cached: :boolean,
+    citations: :map,
+    passages: {:list, :map},
+    metadata: {:optional, :map}
+  }
+
   @contracts [
     %{
       module: Actions.Snapshot,
@@ -31,6 +52,20 @@ defmodule Jido.Browser.ActionContractContentCompositeTest do
           default: "body",
           doc: "CSS selector to scope extraction"
         }
+      },
+      output: %{
+        status: {:literal, "success"},
+        session: :any,
+        url: {:optional, {:nullable, :string}},
+        title: {:optional, {:nullable, :string}},
+        origin: {:optional, {:nullable, :string}},
+        snapshot: {:optional, :string},
+        content: {:optional, :string},
+        refs: {:optional, :map},
+        links: {:optional, {:list, :map}},
+        forms: {:optional, {:list, :map}},
+        headings: {:optional, {:list, :map}},
+        raw: {:optional, :map}
       }
     },
     %{
@@ -49,6 +84,15 @@ defmodule Jido.Browser.ActionContractContentCompositeTest do
           doc: "Image format (only PNG is currently supported)"
         },
         save_path: %{type: :string, doc: "Optional file path to save the screenshot"}
+      },
+      output: %{
+        status: {:literal, "success"},
+        mime: :string,
+        size: :non_neg_integer,
+        base64: :string,
+        session: :any,
+        saved_to: {:optional, :string},
+        save_error: {:optional, :string}
       }
     },
     %{
@@ -66,6 +110,13 @@ defmodule Jido.Browser.ActionContractContentCompositeTest do
           default: :markdown,
           doc: "Output format"
         }
+      },
+      output: %{
+        status: {:literal, "success"},
+        content: :string,
+        format: {:in, [:markdown, :html, :text]},
+        length: :non_neg_integer,
+        session: :any
       }
     },
     %{
@@ -145,7 +196,8 @@ defmodule Jido.Browser.ActionContractContentCompositeTest do
           type: :integer,
           doc: "Maximum successful web fetch calls allowed in current skill state"
         }
-      }
+      },
+      output: @web_fetch_output
     },
     %{
       module: Actions.FetchRich,
@@ -239,7 +291,13 @@ defmodule Jido.Browser.ActionContractContentCompositeTest do
           type: :integer,
           doc: "Maximum successful rich fetch calls allowed in current skill state"
         }
-      }
+      },
+      output:
+        Map.merge(@web_fetch_output, %{
+          retrieval_path: {:in, [:web_fetch, :browser]},
+          fallback_reason: :any,
+          blocked?: :boolean
+        })
     },
     %{
       module: Actions.ReadPage,
@@ -264,6 +322,11 @@ defmodule Jido.Browser.ActionContractContentCompositeTest do
         adapter: %{type: :atom, doc: "Browser adapter module"},
         headless: %{type: :boolean, doc: "Run in headless mode"},
         timeout: %{type: :integer, doc: "Default browser timeout in ms"}
+      },
+      output: %{
+        url: :string,
+        content: :string,
+        format: {:in, [:markdown, :text, :html]}
       }
     },
     %{
@@ -296,6 +359,20 @@ defmodule Jido.Browser.ActionContractContentCompositeTest do
         adapter: %{type: :atom, doc: "Browser adapter module"},
         headless: %{type: :boolean, doc: "Run in headless mode"},
         timeout: %{type: :integer, doc: "Default browser timeout in ms"}
+      },
+      output: %{
+        status: {:literal, "success"},
+        url: {:optional, {:nullable, :string}},
+        title: {:optional, {:nullable, :string}},
+        origin: {:optional, {:nullable, :string}},
+        snapshot: {:optional, :string},
+        content: {:optional, :string},
+        refs: {:optional, :map},
+        links: {:optional, {:list, :map}},
+        forms: {:optional, {:list, :map}},
+        headings: {:optional, {:list, :map}},
+        fallback: {:optional, :boolean},
+        raw: {:optional, :map}
       }
     },
     %{
@@ -325,6 +402,11 @@ defmodule Jido.Browser.ActionContractContentCompositeTest do
           type: :string,
           doc: "Freshness filter: pd (24h), pw (week), pm (month), py (year)"
         }
+      },
+      output: %{
+        query: :string,
+        results: {:list, :map},
+        count: :non_neg_integer
       }
     }
   ]
@@ -351,12 +433,14 @@ defmodule Jido.Browser.ActionContractContentCompositeTest do
     assert MapSet.new(contract_modules) == MapSet.new(production_modules)
   end
 
-  test "uses static Zoi object input schemas for every production action" do
+  test "uses static Zoi object input and output schemas for every production action" do
     for action <- production_actions() do
-      assert %Zoi.Types.Map{fields: fields} = schema = action.schema()
-      assert is_list(fields)
-      refute schema_contains?(schema, &is_function/1)
-      refute schema_contains?(schema, &match?(%Zoi.Types.Lazy{}, &1))
+      for schema <- [action.schema(), action.output_schema()] do
+        assert %Zoi.Types.Map{fields: fields} = schema
+        assert is_list(fields)
+        refute schema_contains?(schema, &is_function/1)
+        refute schema_contains?(schema, &match?(%Zoi.Types.Lazy{}, &1))
+      end
     end
   end
 

--- a/test/jido_browser/action_contract_interaction_query_test.exs
+++ b/test/jido_browser/action_contract_interaction_query_test.exs
@@ -21,6 +21,12 @@ defmodule Jido.Browser.ActionContractInteractionQueryTest do
           doc: "Optional text content to match within the selector"
         },
         timeout: %{type: :integer, doc: "Timeout in milliseconds"}
+      },
+      output: %{
+        status: {:literal, "success"},
+        selector: :string,
+        result: :map,
+        session: :any
       }
     },
     %{
@@ -36,6 +42,12 @@ defmodule Jido.Browser.ActionContractInteractionQueryTest do
         text: %{type: :string, required: true, doc: "Text to type into the element"},
         clear: %{type: :boolean, default: false, doc: "Clear the field before typing"},
         timeout: %{type: :integer, doc: "Timeout in milliseconds"}
+      },
+      output: %{
+        status: {:literal, "success"},
+        selector: :string,
+        result: :map,
+        session: :any
       }
     },
     %{
@@ -49,6 +61,12 @@ defmodule Jido.Browser.ActionContractInteractionQueryTest do
           doc: "CSS selector for the element to hover"
         },
         timeout: %{type: :integer, doc: "Timeout in milliseconds"}
+      },
+      output: %{
+        status: {:literal, "success"},
+        selector: :string,
+        result: :map,
+        session: :any
       }
     },
     %{
@@ -62,6 +80,12 @@ defmodule Jido.Browser.ActionContractInteractionQueryTest do
           doc: "CSS selector for the element to focus"
         },
         timeout: %{type: :integer, doc: "Timeout in milliseconds"}
+      },
+      output: %{
+        status: {:literal, "success"},
+        selector: :string,
+        result: :map,
+        session: :any
       }
     },
     %{
@@ -76,6 +100,11 @@ defmodule Jido.Browser.ActionContractInteractionQueryTest do
           doc: "Preset scroll direction"
         },
         selector: %{type: :string, doc: "CSS selector to scroll element into view"}
+      },
+      output: %{
+        status: {:literal, "success"},
+        result: :map,
+        session: :any
       }
     },
     %{
@@ -91,6 +120,12 @@ defmodule Jido.Browser.ActionContractInteractionQueryTest do
         value: %{type: :string, doc: "Option value to select"},
         label: %{type: :string, doc: "Option label/text to select"},
         index: %{type: :integer, doc: "Option index to select (0-based)"}
+      },
+      output: %{
+        status: {:literal, "success"},
+        selector: :string,
+        result: :map,
+        session: :any
       }
     },
     %{
@@ -99,6 +134,10 @@ defmodule Jido.Browser.ActionContractInteractionQueryTest do
       description: "Wait for a specified number of milliseconds",
       schema: %{
         ms: %{type: :integer, required: true, doc: "Milliseconds to wait"}
+      },
+      output: %{
+        status: {:literal, "success"},
+        waited_ms: :integer
       }
     },
     %{
@@ -117,6 +156,13 @@ defmodule Jido.Browser.ActionContractInteractionQueryTest do
           default: 30_000,
           doc: "Maximum wait time in milliseconds"
         }
+      },
+      output: %{
+        status: {:literal, "success"},
+        selector: :string,
+        state: {:in, [:attached, :visible, :hidden, :detached]},
+        elapsed_ms: :non_neg_integer,
+        session: :any
       }
     },
     %{
@@ -130,6 +176,12 @@ defmodule Jido.Browser.ActionContractInteractionQueryTest do
           default: 30_000,
           doc: "Maximum wait time in milliseconds"
         }
+      },
+      output: %{
+        status: {:literal, "success"},
+        url: {:nullable, :string},
+        elapsed_ms: :non_neg_integer,
+        session: :any
       }
     },
     %{
@@ -139,6 +191,12 @@ defmodule Jido.Browser.ActionContractInteractionQueryTest do
       schema: %{
         selector: %{type: :string, required: true, doc: "CSS selector to query"},
         limit: %{type: :integer, default: 10, doc: "Maximum number of elements to return"}
+      },
+      output: %{
+        status: {:literal, "success"},
+        count: :non_neg_integer,
+        elements: {:list, :map},
+        session: :any
       }
     },
     %{
@@ -152,6 +210,13 @@ defmodule Jido.Browser.ActionContractInteractionQueryTest do
           default: false,
           doc: "Get text from all matching elements"
         }
+      },
+      output: %{
+        status: {:literal, "success"},
+        selector: :string,
+        text: {:optional, :string},
+        texts: {:optional, {:list, :string}},
+        session: :any
       }
     },
     %{
@@ -161,6 +226,13 @@ defmodule Jido.Browser.ActionContractInteractionQueryTest do
       schema: %{
         selector: %{type: :string, required: true, doc: "CSS selector for the element"},
         attribute: %{type: :string, required: true, doc: "Attribute name to get"}
+      },
+      output: %{
+        status: {:literal, "success"},
+        selector: :string,
+        attribute: :string,
+        value: :string,
+        session: :any
       }
     },
     %{
@@ -169,6 +241,11 @@ defmodule Jido.Browser.ActionContractInteractionQueryTest do
       description: "Check if an element is visible",
       schema: %{
         selector: %{type: :string, required: true, doc: "CSS selector for the element"}
+      },
+      output: %{
+        exists: :boolean,
+        visible: :boolean,
+        session: :any
       }
     },
     %{
@@ -178,6 +255,11 @@ defmodule Jido.Browser.ActionContractInteractionQueryTest do
       schema: %{
         script: %{type: :string, required: true, doc: "JavaScript code to execute"},
         timeout: %{type: :integer, doc: "Timeout in milliseconds"}
+      },
+      output: %{
+        status: {:literal, "success"},
+        result: :any,
+        session: :any
       }
     },
     %{
@@ -186,6 +268,12 @@ defmodule Jido.Browser.ActionContractInteractionQueryTest do
       description: "Read browser console messages",
       schema: %{
         timeout: %{type: :integer, doc: "Timeout in milliseconds"}
+      },
+      output: %{
+        status: {:literal, "success"},
+        messages: {:list, :map},
+        result: :map,
+        session: :any
       }
     },
     %{
@@ -194,6 +282,12 @@ defmodule Jido.Browser.ActionContractInteractionQueryTest do
       description: "Read browser runtime errors",
       schema: %{
         timeout: %{type: :integer, doc: "Timeout in milliseconds"}
+      },
+      output: %{
+        status: {:literal, "success"},
+        errors: {:list, :map},
+        result: :map,
+        session: :any
       }
     }
   ]

--- a/test/jido_browser/action_contract_lifecycle_navigation_test.exs
+++ b/test/jido_browser/action_contract_lifecycle_navigation_test.exs
@@ -16,19 +16,37 @@ defmodule Jido.Browser.ActionContractLifecycleNavigationTest do
         adapter: %{type: :atom, doc: "Browser adapter module"},
         pool: %{type: :any, doc: "Optional warm session pool name"},
         checkout_timeout: %{type: :integer, doc: "Warm pool checkout timeout in ms"}
+      },
+      output: %{
+        status: {:literal, "success"},
+        session: :any,
+        adapter: :string,
+        message: :string
       }
     },
     %{
       module: Actions.EndSession,
       name: "browser_end_session",
       description: "End the current browser session",
-      schema: %{}
+      schema: %{},
+      output: %{
+        status: {:literal, "success"},
+        message: :string
+      }
     },
     %{
       module: Actions.GetStatus,
       name: "browser_get_status",
       description: "Get current session status (url, title, is_alive)",
-      schema: %{}
+      schema: %{},
+      output: %{
+        status: {:literal, "success"},
+        alive: :boolean,
+        url: {:nullable, :string},
+        title: {:nullable, :string},
+        adapter: :string,
+        session: :any
+      }
     },
     %{
       module: Actions.PoolStatus,
@@ -36,6 +54,11 @@ defmodule Jido.Browser.ActionContractLifecycleNavigationTest do
       description: "Return readiness and lifecycle status for a warm browser pool.",
       schema: %{
         pool: %{type: :any, doc: "Warm pool name or pid. Defaults to plugin pool state."}
+      },
+      output: %{
+        status: {:literal, "success"},
+        pool: :any,
+        pool_status: :map
       }
     },
     %{
@@ -45,6 +68,12 @@ defmodule Jido.Browser.ActionContractLifecycleNavigationTest do
       schema: %{
         url: %{type: :string, required: true, doc: "The URL to navigate to"},
         timeout: %{type: :integer, doc: "Timeout in milliseconds"}
+      },
+      output: %{
+        status: {:literal, "success"},
+        url: :string,
+        result: :map,
+        session: :any
       }
     },
     %{
@@ -53,6 +82,12 @@ defmodule Jido.Browser.ActionContractLifecycleNavigationTest do
       description: "Navigate back in browser history",
       schema: %{
         timeout: %{type: :integer, doc: "Timeout in milliseconds"}
+      },
+      output: %{
+        status: {:literal, "success"},
+        action: {:literal, "back"},
+        result: :map,
+        session: :any
       }
     },
     %{
@@ -61,6 +96,12 @@ defmodule Jido.Browser.ActionContractLifecycleNavigationTest do
       description: "Navigate forward in browser history",
       schema: %{
         timeout: %{type: :integer, doc: "Timeout in milliseconds"}
+      },
+      output: %{
+        status: {:literal, "success"},
+        action: {:literal, "forward"},
+        result: :map,
+        session: :any
       }
     },
     %{
@@ -69,6 +110,12 @@ defmodule Jido.Browser.ActionContractLifecycleNavigationTest do
       description: "Reload the current page",
       schema: %{
         timeout: %{type: :integer, doc: "Timeout in milliseconds"}
+      },
+      output: %{
+        status: {:literal, "success"},
+        action: {:literal, "reload"},
+        result: :map,
+        session: :any
       }
     },
     %{
@@ -77,6 +124,11 @@ defmodule Jido.Browser.ActionContractLifecycleNavigationTest do
       description: "Get the current page URL",
       schema: %{
         timeout: %{type: :integer, doc: "Timeout in milliseconds"}
+      },
+      output: %{
+        status: {:literal, "success"},
+        url: :string,
+        session: :any
       }
     },
     %{
@@ -85,6 +137,11 @@ defmodule Jido.Browser.ActionContractLifecycleNavigationTest do
       description: "Get the current page title",
       schema: %{
         timeout: %{type: :integer, doc: "Timeout in milliseconds"}
+      },
+      output: %{
+        status: {:literal, "success"},
+        title: :string,
+        session: :any
       }
     },
     %{
@@ -94,6 +151,12 @@ defmodule Jido.Browser.ActionContractLifecycleNavigationTest do
       schema: %{
         url: %{type: :string, doc: "Optional URL to open in the new tab"},
         timeout: %{type: :integer, doc: "Timeout in milliseconds"}
+      },
+      output: %{
+        status: {:literal, "success"},
+        url: {:nullable, :string},
+        result: :map,
+        session: :any
       }
     },
     %{
@@ -103,6 +166,12 @@ defmodule Jido.Browser.ActionContractLifecycleNavigationTest do
       schema: %{
         index: %{type: :integer, doc: "Optional tab index to close"},
         timeout: %{type: :integer, doc: "Timeout in milliseconds"}
+      },
+      output: %{
+        status: {:literal, "success"},
+        index: {:nullable, :integer},
+        result: :map,
+        session: :any
       }
     },
     %{
@@ -112,6 +181,12 @@ defmodule Jido.Browser.ActionContractLifecycleNavigationTest do
       schema: %{
         index: %{type: :integer, required: true, doc: "Tab index to activate"},
         timeout: %{type: :integer, doc: "Timeout in milliseconds"}
+      },
+      output: %{
+        status: {:literal, "success"},
+        index: :integer,
+        result: :map,
+        session: :any
       }
     },
     %{
@@ -120,6 +195,12 @@ defmodule Jido.Browser.ActionContractLifecycleNavigationTest do
       description: "List open browser tabs",
       schema: %{
         timeout: %{type: :integer, doc: "Timeout in milliseconds"}
+      },
+      output: %{
+        status: {:literal, "success"},
+        tabs: {:list, :map},
+        result: :map,
+        session: :any
       }
     },
     %{
@@ -133,6 +214,12 @@ defmodule Jido.Browser.ActionContractLifecycleNavigationTest do
           doc: "Filesystem path where session state will be stored"
         },
         timeout: %{type: :integer, doc: "Timeout in milliseconds"}
+      },
+      output: %{
+        status: {:literal, "success"},
+        path: :string,
+        result: :map,
+        session: :any
       }
     },
     %{
@@ -146,6 +233,12 @@ defmodule Jido.Browser.ActionContractLifecycleNavigationTest do
           doc: "Filesystem path of the saved session state"
         },
         timeout: %{type: :integer, doc: "Timeout in milliseconds"}
+      },
+      output: %{
+        status: {:literal, "success"},
+        path: :string,
+        result: :map,
+        session: :any
       }
     }
   ]

--- a/test/jido_browser/actions_test.exs
+++ b/test/jido_browser/actions_test.exs
@@ -330,6 +330,7 @@ defmodule Jido.Browser.ActionsTest do
       end)
 
       assert {:ok, result} = Actions.Snapshot.run(%{}, context)
+      assert {:ok, ^result} = Actions.Snapshot.validate_output(result)
       assert result.status == "success"
       assert result.url == "https://example.com"
       assert result.title == "Example Page"
@@ -342,8 +343,9 @@ defmodule Jido.Browser.ActionsTest do
         {:ok, sess, %{content: "# Hello World\n\nThis is the page content.", format: :markdown}}
       end)
 
-      assert {:ok, %{status: "success", content: content, format: :markdown, session: ^session}} =
-               Actions.ExtractContent.run(%{}, context)
+      assert {:ok, result} = Actions.ExtractContent.run(%{}, context)
+      assert {:ok, ^result} = Actions.ExtractContent.validate_output(result)
+      assert %{status: "success", content: content, format: :markdown, session: ^session} = result
 
       assert content =~ "Hello World"
     end
@@ -375,8 +377,9 @@ defmodule Jido.Browser.ActionsTest do
         {:ok, sess, %{bytes: png_bytes, mime: "image/png"}}
       end)
 
-      assert {:ok, %{status: "success", mime: "image/png", size: 8, base64: _, session: ^session}} =
-               Actions.Screenshot.run(%{}, context)
+      assert {:ok, result} = Actions.Screenshot.run(%{}, context)
+      assert {:ok, ^result} = Actions.Screenshot.validate_output(result)
+      assert %{status: "success", mime: "image/png", size: 8, base64: _, session: ^session} = result
     end
   end
 

--- a/test/jido_browser/adapters/agent_browser_smoke_test.exs
+++ b/test/jido_browser/adapters/agent_browser_smoke_test.exs
@@ -12,6 +12,7 @@ defmodule Jido.Browser.Adapters.AgentBrowserSmokeTest do
   use ExUnit.Case, async: false
 
   alias Jido.Browser
+  alias Jido.Browser.Actions
   alias Jido.Browser.Adapters.AgentBrowser
   alias Jido.Browser.AgentBrowser.Runtime
   alias Jido.Browser.TestSupport.IntegrationTestServer
@@ -53,10 +54,21 @@ defmodule Jido.Browser.Adapters.AgentBrowserSmokeTest do
 
     on_exit(fn -> assert :ok = end_session_if_running(session) end)
 
-    assert {:ok, session, _navigate_result} =
+    assert {:ok, session, navigate_result} =
              Browser.navigate(session, "#{base_url}/refs", timeout: @command_timeout)
 
+    navigate_output = %{
+      status: "success",
+      url: "#{base_url}/refs",
+      result: navigate_result,
+      session: session
+    }
+
+    assert {:ok, ^navigate_output} = Actions.Navigate.validate_output(navigate_output)
+
     assert {:ok, session, snapshot_result} = Browser.snapshot(session, timeout: @command_timeout)
+    snapshot_output = snapshot_result |> Map.put(:status, "success") |> Map.put(:session, session)
+    assert {:ok, ^snapshot_output} = Actions.Snapshot.validate_output(snapshot_output)
     refs = fetch_value(snapshot_result, :refs)
 
     assert is_binary(fetch_value(snapshot_result, :snapshot))

--- a/test/jido_browser/adapters/lightpanda_integration_test.exs
+++ b/test/jido_browser/adapters/lightpanda_integration_test.exs
@@ -8,6 +8,7 @@ defmodule Jido.Browser.Adapters.LightpandaIntegrationTest do
   use ExUnit.Case, async: false
 
   alias Jido.Browser
+  alias Jido.Browser.Actions
   alias Jido.Browser.Adapters.Lightpanda
   alias Jido.Browser.Installer
   alias Jido.Browser.TestSupport.IntegrationTestServer
@@ -48,6 +49,15 @@ defmodule Jido.Browser.Adapters.LightpandaIntegrationTest do
     } do
       {:ok, session, nav_result} = Browser.navigate(session, "#{base_url}/", timeout: @command_timeout)
       assert nav_result.url == "#{base_url}/"
+
+      navigate_output = %{
+        status: "success",
+        url: "#{base_url}/",
+        result: nav_result,
+        session: session
+      }
+
+      assert {:ok, ^navigate_output} = Actions.Navigate.validate_output(navigate_output)
 
       {:ok, session, title_result} = Browser.get_title(session, timeout: @command_timeout)
       assert title_result.title == "Integration Test Home"

--- a/test/jido_browser/adapters/vibium_integration_test.exs
+++ b/test/jido_browser/adapters/vibium_integration_test.exs
@@ -7,6 +7,7 @@ defmodule Jido.Browser.Adapters.VibiumIntegrationTest do
   """
   use ExUnit.Case, async: false
 
+  alias Jido.Browser.Actions
   alias Jido.Browser.Adapters.Vibium
   alias Jido.Browser.TestSupport.IntegrationTestServer
 
@@ -35,8 +36,11 @@ defmodule Jido.Browser.Adapters.VibiumIntegrationTest do
   describe "navigate/3" do
     test "fetches local fixture webpage", %{session: session, base_url: base_url} do
       url = "#{base_url}/"
-      {:ok, _session, result} = Vibium.navigate(session, url, timeout: @command_timeout)
+      {:ok, output_session, result} = Vibium.navigate(session, url, timeout: @command_timeout)
       assert result.url == url
+
+      navigate_output = %{status: "success", url: url, result: result, session: output_session}
+      assert {:ok, ^navigate_output} = Actions.Navigate.validate_output(navigate_output)
     end
 
     test "navigates to a second local page", %{session: session, base_url: base_url} do

--- a/test/jido_browser/composite_actions_and_installer_test.exs
+++ b/test/jido_browser/composite_actions_and_installer_test.exs
@@ -65,6 +65,7 @@ defmodule Jido.Browser.CompositeActionsAndInstallerTest do
                  }
                )
 
+      assert {:ok, ^result} = ReadPage.validate_output(result)
       assert result.url == "https://example.com"
       assert result.content == "Example body"
       assert result.format == :text
@@ -120,6 +121,7 @@ defmodule Jido.Browser.CompositeActionsAndInstallerTest do
                  }
                })
 
+      assert {:ok, ^result} = SnapshotUrl.validate_output(result)
       assert result[:status] == "success"
       assert result.title == "Example Domain"
     end
@@ -149,6 +151,7 @@ defmodule Jido.Browser.CompositeActionsAndInstallerTest do
                  %{}
                )
 
+      assert {:ok, ^result} = SnapshotUrl.validate_output(result)
       assert result[:status] == "success"
       assert result[:fallback] == true
       assert result[:content] == "abcdefgh"
@@ -182,6 +185,7 @@ defmodule Jido.Browser.CompositeActionsAndInstallerTest do
         end)
 
         assert {:ok, result} = SearchWeb.run(%{query: "elixir language", max_results: 50}, %{})
+        assert {:ok, ^result} = SearchWeb.validate_output(result)
         assert result.count == 1
         assert hd(result.results).title == "Elixir"
         assert hd(result.results).rank == 1
@@ -251,6 +255,7 @@ defmodule Jido.Browser.CompositeActionsAndInstallerTest do
                  context
                )
 
+      assert {:ok, ^result} = WebFetch.validate_output(result)
       assert result.status == "success"
       assert result.url == "https://example.com/guide"
     end
@@ -300,6 +305,7 @@ defmodule Jido.Browser.CompositeActionsAndInstallerTest do
                  %{skill_state: %{web_fetch_uses: 0}}
                )
 
+      assert {:ok, ^result} = WebFetch.validate_output(result)
       assert result.status == "success"
     end
   end
@@ -322,8 +328,13 @@ defmodule Jido.Browser.CompositeActionsAndInstallerTest do
            format: :markdown,
            content_type: "text/html",
            document_type: :html,
+           retrieved_at: "2026-03-21T00:00:00Z",
            estimated_tokens: 6,
+           original_estimated_tokens: 6,
            truncated: false,
+           filtered: false,
+           focus_matches: 0,
+           cached: false,
            citations: %{enabled: false},
            passages: [],
            retrieval_path: :browser,
@@ -345,6 +356,7 @@ defmodule Jido.Browser.CompositeActionsAndInstallerTest do
                  context
                )
 
+      assert {:ok, ^result} = FetchRich.validate_output(result)
       assert result.status == "success"
       assert result.retrieval_path == :browser
     end

--- a/test/support/action_contract_assertions.ex
+++ b/test/support/action_contract_assertions.ex
@@ -9,13 +9,126 @@ defmodule Jido.Browser.ActionContractAssertions do
   @unknown_atom :contract_unknown_atom
   @unknown_string "contract_unknown_string"
 
-  def assert_contract(%{module: action, name: name, description: description, schema: schema}) do
+  def assert_contract(%{module: action, name: name, description: description, schema: schema} = contract) do
     assert Schema.schema_type(action.schema()) == :zoi
 
     assert_validation_contract(action, schema)
     assert_tool_input_contract(action, schema)
     assert_generated_tool_contract(action, name, description, schema)
+
+    case contract do
+      %{output: output} -> assert_output_contract(action, output)
+      _contract -> :ok
+    end
   end
+
+  defp assert_output_contract(action, output) do
+    output_schema = action.output_schema()
+
+    assert Schema.schema_type(output_schema) == :zoi
+    assert %Zoi.Types.Map{} = output_schema
+    refute schema_contains?(output_schema, &is_function/1)
+    refute schema_contains?(output_schema, &match?(%Zoi.Types.Lazy{}, &1))
+
+    assert output_schema
+           |> Schema.known_keys()
+           |> MapSet.new() == MapSet.new(Map.keys(output))
+
+    sample = Map.new(output, fn {key, type} -> {key, output_sample(type, key)} end)
+    assert {:ok, ^sample} = action.validate_output(sample)
+
+    output_with_unknown_keys =
+      Map.merge(sample, %{@unknown_atom => :kept, @unknown_string => "kept"})
+
+    assert {:ok, ^output_with_unknown_keys} = action.validate_output(output_with_unknown_keys)
+
+    for {key, type} <- output do
+      assert_output_presence(action, sample, key, type)
+      assert_output_type(action, sample, key, type)
+      assert_nullable_output(action, sample, key, type)
+    end
+  end
+
+  defp assert_output_presence(action, sample, key, {:optional, _type}) do
+    expected = Map.delete(sample, key)
+    assert {:ok, ^expected} = action.validate_output(expected)
+  end
+
+  defp assert_output_presence(action, sample, key, _type) do
+    assert {:error, _reason} = action.validate_output(Map.delete(sample, key))
+  end
+
+  defp assert_output_type(action, sample, key, type) do
+    case invalid_output_value(type) do
+      :unconstrained ->
+        :ok
+
+      invalid ->
+        assert {:error, _reason} = action.validate_output(Map.put(sample, key, invalid))
+    end
+  end
+
+  defp assert_nullable_output(action, sample, key, {:nullable, _type}) do
+    expected = Map.put(sample, key, nil)
+    assert {:ok, ^expected} = action.validate_output(expected)
+  end
+
+  defp assert_nullable_output(action, sample, key, {:optional, type}) do
+    assert_nullable_output(action, sample, key, type)
+  end
+
+  defp assert_nullable_output(_action, _sample, _key, _type), do: :ok
+
+  defp output_sample({:literal, value}, _key), do: value
+  defp output_sample({:nullable, type}, key), do: output_sample(type, key)
+  defp output_sample({:optional, type}, key), do: output_sample(type, key)
+  defp output_sample({:list, type}, key), do: [output_sample(type, key)]
+  defp output_sample({:in, [value | _values]}, _key), do: value
+  defp output_sample(:string, key), do: "sample_#{key}"
+  defp output_sample(:integer, _key), do: 7
+  defp output_sample(:non_neg_integer, _key), do: 0
+  defp output_sample(:boolean, _key), do: true
+  defp output_sample(:atom, _key), do: :contract_sample
+  defp output_sample(:map, _key), do: %{contract: "sample"}
+  defp output_sample(:any, _key), do: {:contract, :sample}
+
+  defp invalid_output_value({:literal, value}) when is_binary(value), do: value <> "_invalid"
+  defp invalid_output_value({:literal, value}), do: {:not, value}
+  defp invalid_output_value({:nullable, type}), do: invalid_output_value(type)
+  defp invalid_output_value({:optional, type}), do: invalid_output_value(type)
+  defp invalid_output_value({:list, _type}), do: %{}
+  defp invalid_output_value({:in, _values}), do: :contract_invalid
+  defp invalid_output_value(:string), do: 7
+  defp invalid_output_value(:integer), do: "not-an-integer"
+  defp invalid_output_value(:non_neg_integer), do: -1
+  defp invalid_output_value(:boolean), do: "not-a-boolean"
+  defp invalid_output_value(:atom), do: "not-an-atom"
+  defp invalid_output_value(:map), do: []
+  defp invalid_output_value(:any), do: :unconstrained
+
+  defp schema_contains?(value, predicate) do
+    predicate.(value) or schema_children_contain?(value, predicate)
+  end
+
+  defp schema_children_contain?(value, predicate) when is_map(value) do
+    value
+    |> Map.to_list()
+    |> Enum.any?(fn {key, child} ->
+      schema_contains?(key, predicate) or schema_contains?(child, predicate)
+    end)
+  end
+
+  defp schema_children_contain?(value, predicate) when is_tuple(value) do
+    value
+    |> Tuple.to_list()
+    |> Enum.any?(&schema_contains?(&1, predicate))
+  end
+
+  defp schema_children_contain?(value, predicate) when is_list(value) do
+    Enum.any?(value, &schema_contains?(&1, predicate))
+  end
+
+  defp schema_children_contain?(_value, _predicate), do: false
 
   defp assert_validation_contract(action, schema) do
     all_atom_params = sample_params(schema)


### PR DESCRIPTION
Closes #91

## Summary

- add static Zoi output schemas to all 40 browser actions
- match the normalized public result contracts from #82, including native and fallback snapshot shapes
- validate required, optional, nullable, literal, collection, and opaque fields in contract tests
- prove output validation against AgentBrowser, Lightpanda, and Vibium integration result paths

## Focused commits

1. `feat(actions): add lifecycle and navigation output schemas`
2. `feat(actions): add interaction and query output schemas`
3. `feat(actions): add content and composite output schemas`

## Verification

- `mix compile --warnings-as-errors`
- `mix test` — 375 passed, 20 integration tests excluded
- `mise exec node@25.7.0 -- mix test test/jido_browser/adapters/vibium_integration_test.exs --include integration` — 7 passed
- AgentBrowser and Lightpanda integration files compile locally; AgentBrowser 0.35.1 smoke runs in PR CI

No release or Hex publish is included.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agentjido/codesmith/jido_browser/pr/131"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790631063&installation_model_id=434874&pr_number=131&repository=agentjido%2Fjido_browser&return_to=https%3A%2F%2Fgithub.com%2Fagentjido%2Fjido_browser%2Fpull%2F131&signature=5d03c4714de31dc853874928edb685a31e4402a95efad731bf2fd5aa553d42df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->