### PR TITLE
deps!: make ExtractousEx optional for document extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,25 @@ result.passages
 result.metadata # present when extraction returns document metadata
 ```
 
-`web_fetch/2` keeps HTML handling native for selector extraction and markdown conversion, and uses `extractous_ex` for fetched binary documents such as PDFs, Word, Excel, PowerPoint, OpenDocument, EPUB, and common email formats. Binary document responses may also include `result.metadata` when extraction returns document metadata.
+`web_fetch/2` keeps HTML handling native for selector extraction and markdown
+conversion. Document extraction is optional. Add `extractous_ex` to your
+application when you need to fetch PDFs, Word, Excel, PowerPoint, OpenDocument,
+EPUB, or common email formats:
+
+```elixir
+defp deps do
+  [
+    {:jido_browser, "~> 3.0"},
+    {:extractous_ex, "~> 0.2"}
+  ]
+end
+```
+
+Binary document responses can include `result.metadata` when extraction returns
+document metadata. Without `extractous_ex`, PDF and office document requests
+return an adapter error with `error_code: :unsupported_feature` and
+`feature: :document_extraction`. HTML and text retrieval and browser automation
+do not load ExtractousEx or Rustler.
 
 Web fetches reject loopback, private, link-local, and cloud metadata addresses by default. Set `allow_private_network: true` only when a fetch must reach a trusted private service. Domain allow and block rules still apply when this option is enabled.
 
@@ -339,8 +357,9 @@ config :jido_browser, :web_fetch,
 ```
 
 Configured `req` and `extractous` options are merged with any per-call options
-passed to `Jido.Browser.web_fetch/2`. The top-level `max_response_bytes` value
-is authoritative for the built-in Req backend.
+passed to `Jido.Browser.web_fetch/2`. Extractous options apply only when the host
+application includes the optional `extractous_ex` dependency. The top-level
+`max_response_bytes` value is authoritative for the built-in Req backend.
 
 ## Backends
 

--- a/lib/jido_browser.ex
+++ b/lib/jido_browser.ex
@@ -115,9 +115,10 @@ defmodule Jido.Browser do
   @doc """
   Fetches a URL over HTTP(S) without starting a browser session.
 
-  HTML responses keep native selector extraction and format conversion, while
-  fetched binary documents such as PDFs and office files are extracted through
-  `ExtractousEx`.
+  HTML responses keep native selector extraction and format conversion. Fetched
+  PDFs and office files use the optional `ExtractousEx` dependency. When that
+  dependency is not installed, document requests return an unsupported-feature
+  error without affecting HTML, text, or browser use.
   """
   @spec web_fetch(String.t(), keyword()) :: {:ok, map()} | {:error, term()}
   def web_fetch(url, opts \\ [])

--- a/lib/jido_browser/actions/web_fetch.ex
+++ b/lib/jido_browser/actions/web_fetch.ex
@@ -10,7 +10,7 @@ defmodule Jido.Browser.Actions.WebFetch do
   use Jido.Browser.Action,
     name: "web_fetch",
     description:
-      "Fetch a URL over HTTP(S) with domain policy controls, Extractous-backed document extraction, " <>
+      "Fetch a URL over HTTP(S) with domain policy controls, optional Extractous-backed document extraction, " <>
         "optional focused filtering, approximate token caps, and citation-ready passages.",
     schema:
       Zoi.object(%{

--- a/lib/jido_browser/web_fetch.ex
+++ b/lib/jido_browser/web_fetch.ex
@@ -1,8 +1,8 @@
 defmodule Jido.Browser.WebFetch do
   @moduledoc """
   Stateless HTTP-first web retrieval with optional domain policy, caching,
-  focused filtering, citation-ready passage metadata, and Extractous-backed
-  document extraction.
+  focused filtering, citation-ready passage metadata, and optional
+  Extractous-backed document extraction.
 
   This module is intended for document retrieval workloads where starting a full
   browser session would be unnecessary or too expensive.
@@ -69,7 +69,8 @@ defmodule Jido.Browser.WebFetch do
   - `:cache` - enable ETS cache, defaults to `true`
   - `:cache_ttl_ms` - cache TTL in milliseconds
   - `:require_known_url` / `:known_urls` - optional URL provenance guard
-  - `:extractous` - optional `ExtractousEx` keyword options merged with config
+  - `:extractous` - keyword options for the optional `ExtractousEx` dependency,
+    merged with config
   """
   @spec fetch(String.t(), keyword()) :: {:ok, result()} | {:error, Exception.t()}
   def fetch(url, opts \\ [])

--- a/lib/jido_browser/web_fetch/content.ex
+++ b/lib/jido_browser/web_fetch/content.ex
@@ -2,6 +2,7 @@ defmodule Jido.Browser.WebFetch.Content do
   @moduledoc false
 
   alias Jido.Browser.Error
+  alias Jido.Browser.WebFetch.DocumentExtractor
 
   @html_content_types ["text/html", "application/xhtml+xml"]
   @text_content_types [
@@ -268,7 +269,7 @@ defmodule Jido.Browser.WebFetch.Content do
   end
 
   defp extract_document_content(bytes, final_url, content_type, document_type, opts) do
-    case ExtractousEx.extract_from_bytes(bytes, opts[:extractous]) do
+    case DocumentExtractor.extract(bytes, opts[:extractous]) do
       {:ok, %{content: content, metadata: metadata}} when is_binary(content) ->
         {:ok, String.trim(content), normalize_metadata(metadata)}
 

--- a/lib/jido_browser/web_fetch/content.ex
+++ b/lib/jido_browser/web_fetch/content.ex
@@ -273,6 +273,9 @@ defmodule Jido.Browser.WebFetch.Content do
       {:ok, %{content: content, metadata: metadata}} when is_binary(content) ->
         {:ok, String.trim(content), normalize_metadata(metadata)}
 
+      {:error, :dependency_unavailable} ->
+        {:error, document_extraction_unavailable(final_url, content_type, document_type)}
+
       {:error, reason} ->
         {:error,
          Error.adapter_error("ExtractousEx failed while extracting document content", %{
@@ -293,6 +296,17 @@ defmodule Jido.Browser.WebFetch.Content do
          document_type: document_type,
          reason: error
        })}
+  end
+
+  defp document_extraction_unavailable(final_url, content_type, document_type) do
+    Error.adapter_error("Document extraction support is not installed", %{
+      error_code: :unsupported_feature,
+      feature: :document_extraction,
+      dependency: :extractous_ex,
+      url: final_url,
+      content_type: content_type,
+      document_type: document_type
+    })
   end
 
   defp response_content_type(response) do

--- a/lib/jido_browser/web_fetch/document_extractor.ex
+++ b/lib/jido_browser/web_fetch/document_extractor.ex
@@ -1,9 +1,23 @@
 defmodule Jido.Browser.WebFetch.DocumentExtractor do
   @moduledoc false
 
+  @extractor ExtractousEx
+
+  @compile {:no_warn_undefined, @extractor}
+
+  @doc false
+  @spec available?() :: boolean()
+  def available? do
+    Code.ensure_loaded?(@extractor) and function_exported?(@extractor, :extract_from_bytes, 2)
+  end
+
   @doc false
   @spec extract(binary(), keyword()) :: {:ok, map()} | {:error, term()}
   def extract(bytes, opts) do
-    ExtractousEx.extract_from_bytes(bytes, opts)
+    if available?() do
+      ExtractousEx.extract_from_bytes(bytes, opts)
+    else
+      {:error, :dependency_unavailable}
+    end
   end
 end

--- a/lib/jido_browser/web_fetch/document_extractor.ex
+++ b/lib/jido_browser/web_fetch/document_extractor.ex
@@ -1,0 +1,9 @@
+defmodule Jido.Browser.WebFetch.DocumentExtractor do
+  @moduledoc false
+
+  @doc false
+  @spec extract(binary(), keyword()) :: {:ok, map()} | {:error, term()}
+  def extract(bytes, opts) do
+    ExtractousEx.extract_from_bytes(bytes, opts)
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -70,7 +70,7 @@ defmodule Jido.Browser.MixProject do
       {:jason, "~> 1.4"},
       {:floki, "~> 0.38"},
       {:html2markdown, "~> 0.3"},
-      {:extractous_ex, "~> 0.2"},
+      {:extractous_ex, "~> 0.2", optional: true},
       {:nimble_pool, "~> 1.1"},
 
       # Dev/Test

--- a/test/jido_browser/action_contract_content_composite_test.exs
+++ b/test/jido_browser/action_contract_content_composite_test.exs
@@ -123,7 +123,7 @@ defmodule Jido.Browser.ActionContractContentCompositeTest do
       module: Actions.WebFetch,
       name: "web_fetch",
       description:
-        "Fetch a URL over HTTP(S) with domain policy controls, Extractous-backed document extraction, " <>
+        "Fetch a URL over HTTP(S) with domain policy controls, optional Extractous-backed document extraction, " <>
           "optional focused filtering, approximate token caps, and citation-ready passages.",
       schema: %{
         url: %{type: :string, required: true, doc: "The URL to fetch"},

--- a/test/jido_browser/web_fetch_test.exs
+++ b/test/jido_browser/web_fetch_test.exs
@@ -4,6 +4,7 @@ defmodule Jido.Browser.WebFetchTest do
 
   alias Jido.Browser.Error
   alias Jido.Browser.WebFetch
+  alias Jido.Browser.WebFetch.DocumentExtractor
 
   @result_keys ~w(
     cached citations content content_type document_type estimated_tokens filtered final_url
@@ -32,6 +33,7 @@ defmodule Jido.Browser.WebFetchTest do
   setup_all do
     Mimic.copy(Req)
     Mimic.copy(ExtractousEx)
+    Mimic.copy(DocumentExtractor)
     :ok
   end
 
@@ -267,6 +269,71 @@ defmodule Jido.Browser.WebFetchTest do
 
       assert {:error, %Error.AdapterError{details: %{error_code: :unavailable, document_type: :pdf}}} =
                Jido.Browser.web_fetch("https://example.com/broken.pdf", format: :text)
+    end
+
+    test "returns a stable unsupported-feature error when document extraction is not installed" do
+      pdf_bytes = "%PDF-1.7 unavailable"
+
+      expect(Req, :run, fn opts ->
+        request = Req.Request.new(url: opts[:url])
+
+        response =
+          %Req.Response{
+            status: 200,
+            headers: %{"content-type" => ["application/pdf"]},
+            body: pdf_bytes
+          }
+
+        {request, response}
+      end)
+
+      expect(DocumentExtractor, :extract, fn ^pdf_bytes, [] ->
+        {:error, :dependency_unavailable}
+      end)
+
+      assert {:error,
+              %Error.AdapterError{
+                message: "Document extraction support is not installed",
+                details: %{
+                  error_code: :unsupported_feature,
+                  feature: :document_extraction,
+                  dependency: :extractous_ex,
+                  url: "https://example.com/report.pdf",
+                  content_type: "application/pdf",
+                  document_type: :pdf
+                }
+              }} = Jido.Browser.web_fetch("https://example.com/report.pdf", format: :text)
+    end
+
+    test "does not load the optional document extractor for HTML" do
+      reject(DocumentExtractor, :extract, 2)
+
+      expect(Req, :run, fn opts ->
+        request = Req.Request.new(url: opts[:url])
+
+        response =
+          %Req.Response{
+            status: 200,
+            headers: %{"content-type" => ["text/html"]},
+            body: "<html><body><p>Native HTML</p></body></html>"
+          }
+
+        {request, response}
+      end)
+
+      assert {:ok, result} =
+               Jido.Browser.web_fetch("https://example.com/native.html", format: :text)
+
+      assert result.content == "Native HTML"
+      assert result.document_type == :html
+    end
+
+    test "declares ExtractousEx as an optional application dependency" do
+      assert {:extractous_ex, "~> 0.2", opts} =
+               Enum.find(Mix.Project.config()[:deps], &(elem(&1, 0) == :extractous_ex))
+
+      assert opts[:optional] == true
+      assert :extractous_ex in Application.spec(:jido_browser, :optional_applications)
     end
 
     test "rejects URLs outside allowed_domains" do


### PR DESCRIPTION
## Summary

- isolate all ExtractousEx calls behind one internal document-extractor adapter
- mark ExtractousEx as an optional dependency
- keep PDF and office extraction unchanged when the dependency is installed
- return a stable `:unsupported_feature` adapter error when document extraction is not installed
- keep HTML, text, and browser paths independent from ExtractousEx and Rustler
- document how applications enable optional document extraction

## Stable missing-feature error

```elixir
%Jido.Browser.Error.AdapterError{
  message: "Document extraction support is not installed",
  details: %{
    error_code: :unsupported_feature,
    feature: :document_extraction,
    dependency: :extractous_ex,
    document_type: :pdf
  }
}
```

## Verification

- `mix compile --warnings-as-errors`
- `mix compile --no-optional-deps --warnings-as-errors`
- no-optional runtime start with ExtractousEx and Rustler removed from the code path
- no-optional HTML/text extraction and PDF unsupported-feature result
- `mix test test/jido_browser/web_fetch_test.exs` (21 passed)
- `mix test` (390 passed, 20 excluded)
- `mix credo --strict`
- `mix dialyzer`
- `mix doctor --raise`
- `mix deps.unlock --check-unused`
- `mix docs`

Closes #85

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agentjido/codesmith/jido_browser/pr/134"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790633645&installation_model_id=434874&pr_number=134&repository=agentjido%2Fjido_browser&return_to=https%3A%2F%2Fgithub.com%2Fagentjido%2Fjido_browser%2Fpull%2F134&signature=f1dc6de634eedc1823199e5498fac5f39a514ee16f79cf7ebb4e482b7ed69da0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->