### PR TITLE
refactor!: make browser tool profiles compiler-static

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,7 +306,6 @@ defmodule MyBrowsingAgent do
     plugins: [
       {Jido.Browser.Plugin,
        [
-         profile: :core,
          adapter: Jido.Browser.Adapters.AgentBrowser,
          pool: :default,
          checkout_timeout: 5_000,
@@ -502,22 +501,22 @@ defmodule MyBrowsingAgent do
 end
 ```
 
-The plugin uses the `:core` tool profile by default. It includes 20 actions for
+`Jido.Browser.Plugin` is the core tool profile. It includes 20 actions for
 normal navigation, interaction, waits, page reading, screenshots, web fetches,
-and session close operations. Use the `:debug` profile to add status and live
-page diagnostics.
+and session close operations. Use `Jido.Browser.Plugin.Debug` to add status and
+live page diagnostics.
 
-Existing users who need every browser action can select the `:all` profile:
+Existing users who need every browser action can use the All plugin:
 
 ```elixir
 defmodule MyFullBrowsingAgent do
   use Jido.Agent,
     name: "full_web_browser",
-    plugins: [{Jido.Browser.Plugin, [profile: :all, headless: true]}]
+    plugins: [{Jido.Browser.Plugin.All, [headless: true]}]
 end
 ```
 
-The `:all` profile restores all 40 actions, including browser state, element
+`Jido.Browser.Plugin.All` restores all 40 actions, including browser state, element
 queries, tab management, diagnostics, JavaScript evaluation, and stateless web
 fetch.
 

--- a/lib/jido_browser/plugin.ex
+++ b/lib/jido_browser/plugin.ex
@@ -9,12 +9,11 @@ defmodule Jido.Browser.Plugin do
 
       defmodule MyAgent do
         use Jido.Agent,
-          plugins: [{Jido.Browser.Plugin, [profile: :core, headless: true]}]
+          plugins: [{Jido.Browser.Plugin, [headless: true]}]
       end
 
   ## Configuration Options
 
-  * `:profile` - Tool profile: `:core`, `:debug`, or `:all` (default: `:core`)
   * `:headless` - Run browser in headless mode (default: `true`)
   * `:timeout` - Default timeout in milliseconds (default: `30_000`)
   * `:adapter` - Browser adapter module (optional)
@@ -25,47 +24,24 @@ defmodule Jido.Browser.Plugin do
 
   ## Tool Profiles
 
-  * `:core` - Normal navigation, interaction, waits, page reading, screenshots,
-    and session close operations
-  * `:debug` - The core actions plus status, page identity, console, error, and
-    JavaScript diagnostics
-  * `:all` - Every action in `Jido.Browser.ActionRegistry`
+  * `Jido.Browser.Plugin` - Normal navigation, interaction, waits, page reading,
+    screenshots, and session close operations
+  * `Jido.Browser.Plugin.Debug` - The core actions plus status, page identity,
+    console, error, and JavaScript diagnostics
+  * `Jido.Browser.Plugin.All` - Every action in `Jido.Browser.ActionRegistry`
 
-  Use `profile: :all` to restore the complete action set from Jido Browser 2.x.
+  Use `Jido.Browser.Plugin.All` to restore the complete action set from Jido
+  Browser 2.x. Each profile is a separate module so Jido can compile its exact
+  action and signal contract from static plugin metadata.
   """
 
-  alias Jido.Browser.ActionRegistry
+  alias Jido.Browser.Plugin.Profile
 
-  @default_profile :core
-  @action_modules ActionRegistry.actions(@default_profile)
-  @signal_patterns ActionRegistry.signal_patterns(@default_profile)
-
-  use Jido.Plugin,
-    name: "browser",
-    state_key: :browser,
-    actions: @action_modules,
-    signal_patterns: @signal_patterns,
-    description: "Browser automation for web navigation, interaction, and content extraction",
-    category: "browser",
-    tags: ["browser", "web", "automation", "scraping"],
-    vsn: "2.0.0"
-
-  defoverridable plugin_spec: 1
-
-  @impl Jido.Plugin
-  def plugin_spec(config) do
-    profile = configured_profile(config)
-    spec = super(config)
-
-    %{
-      spec
-      | actions: ActionRegistry.actions(profile),
-        signal_patterns: ActionRegistry.signal_patterns(profile)
-    }
-  end
+  use Profile, profile: :core
 
   @impl Jido.Plugin
   def mount(_agent, config) do
+    :ok = Profile.reject_profile_option!(config)
     adapter = Map.get(config, :adapter, Jido.Browser.Adapters.AgentBrowser)
 
     initial_state = %{
@@ -86,27 +62,6 @@ defmodule Jido.Browser.Plugin do
 
     {:ok, initial_state}
   end
-
-  def schema do
-    Zoi.object(%{
-      session: Zoi.any(description: "Active browser session") |> Zoi.optional(),
-      headless: Zoi.boolean(description: "Run browser in headless mode") |> Zoi.default(true),
-      timeout: Zoi.integer(description: "Default timeout in milliseconds") |> Zoi.default(30_000),
-      adapter: Zoi.atom(description: "Browser adapter module") |> Zoi.optional(),
-      pool: Zoi.any(description: "Named warm session pool") |> Zoi.optional(),
-      checkout_timeout: Zoi.integer(description: "Warm pool checkout timeout in milliseconds") |> Zoi.default(5_000),
-      viewport: Zoi.any(description: "Browser viewport dimensions") |> Zoi.optional(),
-      base_url: Zoi.string(description: "Base URL for relative navigation") |> Zoi.optional(),
-      last_url: Zoi.string(description: "Last navigated URL") |> Zoi.optional(),
-      last_title: Zoi.string(description: "Last page title") |> Zoi.optional(),
-      seen_urls: Zoi.array(Zoi.string(description: "Known URLs discovered during tool use")) |> Zoi.default([]),
-      web_fetch_uses: Zoi.integer(description: "Successful web fetch calls in current skill state") |> Zoi.default(0),
-      fetch_rich_uses: Zoi.integer(description: "Successful rich fetch calls in current skill state") |> Zoi.default(0)
-    })
-  end
-
-  @impl Jido.Plugin
-  def signal_routes(config), do: config |> configured_profile() |> ActionRegistry.signal_routes()
 
   @impl Jido.Plugin
   def handle_signal(_signal, _context) do
@@ -222,10 +177,4 @@ defmodule Jido.Browser.Plugin do
   defp nil_or_empty?(nil), do: true
   defp nil_or_empty?(""), do: true
   defp nil_or_empty?(_value), do: false
-
-  defp configured_profile(config) when is_map(config) do
-    profile = Map.get(config, :profile, @default_profile)
-    ActionRegistry.entries(profile)
-    profile
-  end
 end

--- a/lib/jido_browser/plugin/all.ex
+++ b/lib/jido_browser/plugin/all.ex
@@ -1,0 +1,19 @@
+defmodule Jido.Browser.Plugin.All do
+  @moduledoc """
+  Browser plugin with all registered browser actions.
+
+  Use this module to restore the complete action set from Jido Browser 2.x.
+  """
+
+  use Jido.Browser.Plugin.Profile, profile: :all
+
+  @impl Jido.Plugin
+  def mount(agent, config), do: Jido.Browser.Plugin.mount(agent, config)
+
+  @impl Jido.Plugin
+  def handle_signal(signal, context), do: Jido.Browser.Plugin.handle_signal(signal, context)
+
+  @impl Jido.Plugin
+  def transform_result(action, result, context),
+    do: Jido.Browser.Plugin.transform_result(action, result, context)
+end

--- a/lib/jido_browser/plugin/debug.ex
+++ b/lib/jido_browser/plugin/debug.ex
@@ -1,0 +1,20 @@
+defmodule Jido.Browser.Plugin.Debug do
+  @moduledoc """
+  Browser plugin with the core actions and diagnostic actions.
+
+  Use this module when an agent also needs status, page identity, console,
+  browser error, and JavaScript evaluation actions.
+  """
+
+  use Jido.Browser.Plugin.Profile, profile: :debug
+
+  @impl Jido.Plugin
+  def mount(agent, config), do: Jido.Browser.Plugin.mount(agent, config)
+
+  @impl Jido.Plugin
+  def handle_signal(signal, context), do: Jido.Browser.Plugin.handle_signal(signal, context)
+
+  @impl Jido.Plugin
+  def transform_result(action, result, context),
+    do: Jido.Browser.Plugin.transform_result(action, result, context)
+end

--- a/lib/jido_browser/plugin/profile.ex
+++ b/lib/jido_browser/plugin/profile.ex
@@ -1,0 +1,94 @@
+defmodule Jido.Browser.Plugin.Profile do
+  @moduledoc false
+
+  alias Jido.Browser.ActionRegistry
+
+  @state_schema Zoi.object(%{
+                  session: Zoi.any(description: "Active browser session") |> Zoi.optional(),
+                  headless: Zoi.boolean(description: "Run browser in headless mode") |> Zoi.default(true),
+                  timeout: Zoi.integer(description: "Default timeout in milliseconds") |> Zoi.default(30_000),
+                  adapter: Zoi.atom(description: "Browser adapter module") |> Zoi.optional(),
+                  pool: Zoi.any(description: "Named warm session pool") |> Zoi.optional(),
+                  checkout_timeout:
+                    Zoi.integer(description: "Warm pool checkout timeout in milliseconds") |> Zoi.default(5_000),
+                  viewport: Zoi.any(description: "Browser viewport dimensions") |> Zoi.optional(),
+                  base_url: Zoi.string(description: "Base URL for relative navigation") |> Zoi.optional(),
+                  last_url: Zoi.string(description: "Last navigated URL") |> Zoi.optional(),
+                  last_title: Zoi.string(description: "Last page title") |> Zoi.optional(),
+                  seen_urls:
+                    Zoi.array(Zoi.string(description: "Known URLs discovered during tool use")) |> Zoi.default([]),
+                  web_fetch_uses:
+                    Zoi.integer(description: "Successful web fetch calls in current skill state") |> Zoi.default(0),
+                  fetch_rich_uses:
+                    Zoi.integer(description: "Successful rich fetch calls in current skill state") |> Zoi.default(0)
+                })
+
+  @config_schema Zoi.object(
+                   %{
+                     headless: Zoi.boolean(description: "Run browser in headless mode") |> Zoi.default(true),
+                     timeout: Zoi.integer(description: "Default timeout in milliseconds") |> Zoi.default(30_000),
+                     adapter: Zoi.atom(description: "Browser adapter module") |> Zoi.optional(),
+                     pool: Zoi.any(description: "Named warm session pool") |> Zoi.optional(),
+                     checkout_timeout:
+                       Zoi.integer(description: "Warm pool checkout timeout in milliseconds") |> Zoi.default(5_000),
+                     viewport: Zoi.any(description: "Browser viewport dimensions") |> Zoi.optional(),
+                     base_url: Zoi.string(description: "Base URL for relative navigation") |> Zoi.optional()
+                   },
+                   unrecognized_keys: :error
+                 )
+
+  @doc "Returns the compiler-static browser plugin state schema."
+  @spec state_schema() :: Zoi.schema()
+  def state_schema, do: @state_schema
+
+  @doc "Returns the compiler-static browser plugin configuration schema."
+  @spec config_schema() :: Zoi.schema()
+  def config_schema, do: @config_schema
+
+  @doc "Rejects the removed configuration-dependent profile option."
+  @spec reject_profile_option!(map()) :: :ok
+  def reject_profile_option!(config) when is_map(config) do
+    if Map.has_key?(config, :profile) or Map.has_key?(config, "profile") do
+      raise ArgumentError,
+            "the :profile option is not supported; use Jido.Browser.Plugin.Debug or Jido.Browser.Plugin.All"
+    end
+
+    :ok
+  end
+
+  @doc "Builds a browser plugin module for one static registry profile."
+  defmacro __using__(opts) do
+    profile = Keyword.fetch!(opts, :profile)
+    actions = ActionRegistry.actions(profile)
+    signal_patterns = ActionRegistry.signal_patterns(profile)
+    signal_routes = ActionRegistry.signal_routes(profile)
+
+    quote do
+      alias Jido.Browser.Plugin.Profile, as: ProfileContract
+
+      use Jido.Plugin,
+        name: "browser",
+        state_key: :browser,
+        actions: unquote(actions),
+        schema: unquote(Macro.escape(@state_schema)),
+        config_schema: unquote(Macro.escape(@config_schema)),
+        signal_patterns: unquote(signal_patterns),
+        signal_routes: unquote(Macro.escape(signal_routes)),
+        description: "Browser automation for web navigation, interaction, and content extraction",
+        category: "browser",
+        tags: ["browser", "web", "automation", "scraping"],
+        vsn: "2.0.0"
+
+      defoverridable plugin_spec: 1
+
+      @impl Jido.Plugin
+      def plugin_spec(config) do
+        :ok = ProfileContract.reject_profile_option!(config)
+        super(config)
+      end
+
+      @impl Jido.Plugin
+      def signal_routes(_config), do: signal_routes()
+    end
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -118,6 +118,8 @@ defmodule Jido.Browser.MixProject do
           Jido.Browser.Session,
           Jido.Browser.Result,
           Jido.Browser.Plugin,
+          Jido.Browser.Plugin.Debug,
+          Jido.Browser.Plugin.All,
           Jido.Browser.FetchRich,
           Jido.Browser.WebFetch
         ],

--- a/test/jido_browser/plugin_test.exs
+++ b/test/jido_browser/plugin_test.exs
@@ -2,6 +2,9 @@ defmodule Jido.Browser.PluginTest do
   use ExUnit.Case, async: true
 
   alias Jido.Browser.Plugin
+  alias Jido.Browser.Plugin.All
+  alias Jido.Browser.Plugin.Debug
+  alias Jido.Browser.Plugin.Profile
 
   defmodule DefaultProfileAgent do
     use Jido.Agent,
@@ -9,10 +12,16 @@ defmodule Jido.Browser.PluginTest do
       plugins: [Jido.Browser.Plugin]
   end
 
+  defmodule DebugProfileAgent do
+    use Jido.Agent,
+      name: "browser_debug_profile_test",
+      plugins: [Jido.Browser.Plugin.Debug]
+  end
+
   defmodule AllProfileAgent do
     use Jido.Agent,
       name: "browser_all_profile_test",
-      plugins: [{Jido.Browser.Plugin, [profile: :all]}]
+      plugins: [Jido.Browser.Plugin.All]
   end
 
   @action_registry_contract [
@@ -120,32 +129,56 @@ defmodule Jido.Browser.PluginTest do
     assert Plugin.signal_patterns() == expected_patterns
   end
 
-  test "selects exact debug and all profile contracts in registry order" do
+  test "defines exact static debug and all profile contracts in registry order" do
     all_actions = Enum.map(@action_registry_contract, &elem(&1, 0))
 
-    assert Plugin.plugin_spec(%{profile: :debug}).actions == @debug_action_contract
-    assert Plugin.signal_routes(%{profile: :debug}) == routes_for(@debug_action_contract)
+    assert Debug.actions() == @debug_action_contract
+    assert Debug.signal_routes() == routes_for(@debug_action_contract)
+    assert Debug.signal_routes(%{}) == routes_for(@debug_action_contract)
+    assert Debug.signal_patterns() == signal_patterns_for(@debug_action_contract)
 
-    assert Plugin.plugin_spec(%{profile: :all}).actions == all_actions
+    assert All.actions() == all_actions
 
-    assert Plugin.signal_routes(%{profile: :all}) ==
+    assert All.signal_routes() ==
              Enum.map(@action_registry_contract, fn {action, signal_name} -> {signal_name, action} end)
+
+    assert All.signal_routes(%{}) == All.signal_routes()
+    assert All.signal_patterns() == signal_patterns_for(all_actions)
   end
 
-  test "applies profile selection to compiled Jido agents" do
+  test "applies each static profile to compiled Jido agents" do
     all_actions = Enum.map(@action_registry_contract, &elem(&1, 0))
-    default_spec = browser_spec(DefaultProfileAgent)
-    all_spec = browser_spec(AllProfileAgent)
+    default_spec = browser_spec(DefaultProfileAgent, Plugin)
+    debug_spec = browser_spec(DebugProfileAgent, Debug)
+    all_spec = browser_spec(AllProfileAgent, All)
 
     assert DefaultProfileAgent.actions() == @core_action_contract
+    assert DebugProfileAgent.actions() == @debug_action_contract
     assert AllProfileAgent.actions() == all_actions
     assert default_spec.signal_patterns == signal_patterns_for(@core_action_contract)
+    assert debug_spec.signal_patterns == signal_patterns_for(@debug_action_contract)
     assert all_spec.signal_patterns == signal_patterns_for(all_actions)
   end
 
-  test "rejects unknown profiles" do
-    assert_raise ArgumentError, ~r/unknown browser tool profile :unknown/, fn ->
-      Plugin.plugin_spec(%{profile: :unknown})
+  test "rejects the configuration-dependent profile option" do
+    assert_raise ArgumentError, ~r/use Jido\.Browser\.Plugin\.Debug or Jido\.Browser\.Plugin\.All/, fn ->
+      Plugin.plugin_spec(%{profile: :all})
+    end
+
+    assert_raise ArgumentError, ~r/use Jido\.Browser\.Plugin\.Debug or Jido\.Browser\.Plugin\.All/, fn ->
+      All.mount(%{}, %{"profile" => "core"})
+    end
+  end
+
+  test "keeps state and configuration schemas in static plugin metadata" do
+    for plugin <- [Plugin, Debug, All] do
+      manifest = plugin.manifest()
+
+      assert manifest.schema == Profile.state_schema()
+      assert manifest.config_schema == Profile.config_schema()
+      assert manifest.actions == plugin.actions()
+      assert manifest.signal_patterns == plugin.signal_patterns()
+      assert manifest.signal_routes == plugin.signal_routes()
     end
   end
 
@@ -175,7 +208,7 @@ defmodule Jido.Browser.PluginTest do
     end
 
     test "keeps the complete action set in the all profile" do
-      assert length(Plugin.plugin_spec(%{profile: :all}).actions) == 40
+      assert length(All.actions()) == 40
     end
   end
 
@@ -377,7 +410,7 @@ defmodule Jido.Browser.PluginTest do
 
   defp signal_patterns_for(actions), do: Enum.map(routes_for(actions), &elem(&1, 0))
 
-  defp browser_spec(agent) do
-    Enum.find(agent.plugin_specs(), &(&1.module == Jido.Browser.Plugin))
+  defp browser_spec(agent, plugin) do
+    Enum.find(agent.plugin_specs(), &(&1.module == plugin))
   end
 end


### PR DESCRIPTION
## Summary

- keep `Jido.Browser.Plugin` as the static 20-action core plugin
- add static `Jido.Browser.Plugin.Debug` and `Jido.Browser.Plugin.All` modules
- place actions, state and configuration schemas, signal patterns, and signal routes in compiler-visible metadata
- reject the removed configuration-dependent `profile:` option
- update README examples and compile real Jido agents for all three profiles

## Why

The Jido 3 compiler builds each agent from module-static plugin metadata. A per-agent `profile:` option can silently disagree with the compiled action set. Explicit modules make the profile contract deterministic on both Jido 2 and the candidate Jido 3 compiler.

## Verification

- `mix test`: 396 passed, 20 excluded
- focused plugin tests: 33 passed
- Jido 3 candidate probe: 33 profile tests passed
- combined Jido 3 candidate probe: 395 passed, 20 excluded
- required AgentBrowser smoke: 1 passed
- format, Credo, warnings-as-errors compile, Dialyzer, Doctor, docs: passed
- Hex advisory audit, unused dependency check, and package dry run: passed

The Jido 3 probe used unpublished code only in an isolated local worktree. This pull request keeps the released Jido 2 dependency line. No release or publish action ran.

Closes #136

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agentjido/codesmith/jido_browser/pr/137"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790636432&installation_model_id=434874&pr_number=137&repository=agentjido%2Fjido_browser&return_to=https%3A%2F%2Fgithub.com%2Fagentjido%2Fjido_browser%2Fpull%2F137&signature=78248e121940bcc2ac9657dca0371b2f0b2ed56097c57e96831c9d2aac484afa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->